### PR TITLE
Add classes for storing graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "networkx"
 ]
 description = "A Python package for causal modelling and inference with stochastic causal programming"
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "networkx"
+    "networkx",
 ]
 description = "A Python package for causal modelling and inference with stochastic causal programming"
 dynamic = [

--- a/src/causalprog/__init__.py
+++ b/src/causalprog/__init__.py
@@ -1,18 +1,4 @@
 """causalprog package."""
 
+from . import graph
 from ._version import __version__  # noqa: F401
-
-
-def example_function(argument: str, keyword_argument: str = "default") -> str:
-    """
-    Concatenate string arguments - an example function docstring.
-
-    Args:
-        argument: An argument.
-        keyword_argument: A keyword argument with a default value.
-
-    Returns:
-        The concatenation of `argument` and `keyword_argument`.
-
-    """
-    return argument + keyword_argument

--- a/src/causalprog/__init__.py
+++ b/src/causalprog/__init__.py
@@ -1,4 +1,4 @@
 """causalprog package."""
 
-from . import graph
+from . import graph  # noqa: F401
 from ._version import __version__  # noqa: F401

--- a/src/causalprog/graph/__init__.py
+++ b/src/causalprog/graph/__init__.py
@@ -1,4 +1,4 @@
 """Creation and storage of graphs."""
 
-from .graph import Graph  # noqa: F401
-from .node import DistributionNode, RootDistributionNode  # noqa: F401
+from .graph import Graph
+from .node import DistributionNode, RootDistributionNode

--- a/src/causalprog/graph/__init__.py
+++ b/src/causalprog/graph/__init__.py
@@ -1,0 +1,3 @@
+"""Creation and storage of graphs."""
+
+from .node import RootDistributionNode

--- a/src/causalprog/graph/__init__.py
+++ b/src/causalprog/graph/__init__.py
@@ -1,3 +1,4 @@
 """Creation and storage of graphs."""
 
+from .graph import Graph
 from .node import DistributionNode, RootDistributionNode

--- a/src/causalprog/graph/__init__.py
+++ b/src/causalprog/graph/__init__.py
@@ -1,3 +1,3 @@
 """Creation and storage of graphs."""
 
-from .node import RootDistributionNode
+from .node import DistributionNode, RootDistributionNode

--- a/src/causalprog/graph/__init__.py
+++ b/src/causalprog/graph/__init__.py
@@ -1,4 +1,4 @@
 """Creation and storage of graphs."""
 
-from .graph import Graph
-from .node import DistributionNode, RootDistributionNode
+from .graph import Graph  # noqa: F401
+from .node import DistributionNode, RootDistributionNode  # noqa: F401

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -3,24 +3,18 @@
 import networkx as nx
 from .node import Node
 
-g_index = 0
-
 
 class Graph(object):
     """A directed acyclic graph that represents a causality tree."""
 
-    def __init__(self, graph: nx.Graph, label: str | None = None):
+    def __init__(self, graph: nx.Graph, label: str) -> None:
         """Initialise a graph from a NetworkX graph."""
-        global g_index
+
         for node in graph.nodes:
             if not isinstance(node, Node):
-                raise ValueError(f"Invalid node: {node}")
+                raise TypeError(f"Invalid node: {node}")
 
-        if label is None:
-            self._label = f"Graph{g_index}"
-            g_index += 1
-        else:
-            self.label = label
+        self._label = label
 
         self._graph = graph
         self._nodes = list(graph.nodes())

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -1,0 +1,27 @@
+"""Graph storage."""
+
+import networkx as nx
+from .node import Node
+
+
+class Graph(object):
+    """A directed acyclic graph that represents a causality tree."""
+
+    def __init__(self, graph: nx.Graph):
+        """Initialise a graph from a NetworkX graph."""
+        for node in graph.nodes:
+            if not isinstance(node, Node):
+                raise ValueError(f"Invalid node: {node}")
+
+        self._graph = graph
+        self._nodes = list(graph.nodes())
+        self._depth_first_nodes = list(nx.algorithms.dfs_postorder_nodes(graph))
+
+        self._predecessors = nx.algorithms.dfs_predecessors(graph)
+        self._successors = nx.algorithms.dfs_successors(graph)
+
+        for n in self._nodes:
+            if n not in self._predecessors:
+                self._predecessors[n] = []
+            if n not in self._successors:
+                self._successors[n] = []

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -17,18 +17,9 @@ class Graph:
 
         self._label = label
 
-        self._graph = graph
+        self._graph = graph.copy()
         self._nodes = list(graph.nodes())
         self._depth_first_nodes = list(nx.algorithms.dfs_postorder_nodes(graph))
-
-        self._predecessors = nx.algorithms.dfs_predecessors(graph)
-        self._successors = nx.algorithms.dfs_successors(graph)
-
-        for n in self._nodes:
-            if n not in self._predecessors:
-                self._predecessors[n] = []
-            if n not in self._successors:
-                self._successors[n] = []
 
         outcomes = [node for node in self._nodes if node.is_outcome]
         if len(outcomes) == 0:

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -3,15 +3,24 @@
 import networkx as nx
 from .node import Node
 
+g_index = 0
+
 
 class Graph(object):
     """A directed acyclic graph that represents a causality tree."""
 
-    def __init__(self, graph: nx.Graph):
+    def __init__(self, graph: nx.Graph, label: str | None = None):
         """Initialise a graph from a NetworkX graph."""
+        global g_index
         for node in graph.nodes:
             if not isinstance(node, Node):
                 raise ValueError(f"Invalid node: {node}")
+
+        if label is None:
+            self._label = f"Graph{g_index}"
+            g_index += 1
+        else:
+            self.label = label
 
         self._graph = graph
         self._nodes = list(graph.nodes())
@@ -25,3 +34,15 @@ class Graph(object):
                 self._predecessors[n] = []
             if n not in self._successors:
                 self._successors[n] = []
+
+        outcomes = [node for node in self._nodes if node.is_outcome]
+        if len(outcomes) == 0:
+            raise ValueError("Cannot create graph with no outcome nodes")
+        if len(outcomes) > 1:
+            raise ValueError("Cannot yes create graph with multiple outcome nodes")
+        self._outcome = outcomes[0]
+
+    @property
+    def label(self) -> str:
+        """The label of the graph."""
+        return self._label

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -1,15 +1,15 @@
 """Graph storage."""
 
 import networkx as nx
+
 from .node import Node
 
 
-class Graph(object):
+class Graph:
     """A directed acyclic graph that represents a causality tree."""
 
     def __init__(self, graph: nx.Graph, label: str) -> None:
         """Initialise a graph from a NetworkX graph."""
-
         for node in graph.nodes:
             if not isinstance(node, Node):
                 raise TypeError(f"Invalid node: {node}")

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -12,7 +12,8 @@ class Graph:
         """Initialise a graph from a NetworkX graph."""
         for node in graph.nodes:
             if not isinstance(node, Node):
-                raise TypeError(f"Invalid node: {node}")
+                msg = f"Invalid node: {node}"
+                raise TypeError(msg)
 
         self._label = label
 
@@ -31,9 +32,11 @@ class Graph:
 
         outcomes = [node for node in self._nodes if node.is_outcome]
         if len(outcomes) == 0:
-            raise ValueError("Cannot create graph with no outcome nodes")
+            msg = "Cannot create graph with no outcome nodes"
+            raise ValueError(msg)
         if len(outcomes) > 1:
-            raise ValueError("Cannot yes create graph with multiple outcome nodes")
+            msg = "Cannot yes create graph with multiple outcome nodes"
+            raise ValueError(msg)
         self._outcome = outcomes[0]
 
     @property

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -35,7 +35,7 @@ class Graph:
             msg = "Cannot create graph with no outcome nodes"
             raise ValueError(msg)
         if len(outcomes) > 1:
-            msg = "Cannot yes create graph with multiple outcome nodes"
+            msg = "Cannot yet create graph with multiple outcome nodes"
             raise ValueError(msg)
         self._outcome = outcomes[0]
 

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 from abc import abstractproperty
 
-root_node_index = 0
+dnode_index = 0
+rnode_index = 0
 
 
 class DistributionFamily:  # TODO: import from elsewhere once it exists
@@ -43,12 +44,12 @@ class RootDistributionNode(object):
         self, family: DistributionFamily, label: str = None, is_outcome: bool = False
     ):
         """Initialise the node."""
-        global root_node_index
+        global rnode_index
         self._dfamily = family
 
         if label is None:
-            self._label = f"RootNode{root_node_index}"
-            root_node_index += 1
+            self._label = f"RootDistributionNode{rnode_index}"
+            rnode_index += 1
         else:
             self._label = label
         self._outcome = is_outcome
@@ -72,3 +73,41 @@ class RootDistributionNode(object):
     def is_intermediary(self) -> bool:
         """Is this node an intermediary?"""
         return False
+
+
+class DistributionNode(object):
+    """A node containing a distribution family that depends on its parents."""
+
+    def __init__(
+        self, family: DistributionFamily, label: str = None, is_outcome: bool = False
+    ):
+        """Initialise the node."""
+        global dnode_index
+        self._dfamily = family
+
+        if label is None:
+            self._label = f"DistributionNode{dnode_index}"
+            dnode_index += 1
+        else:
+            self._label = label
+        self._outcome = is_outcome
+
+    @property
+    def label(self) -> str:
+        """The label of the node."""
+        return self._label
+
+    @property
+    def is_root(self) -> bool:
+        """Is this node a root?"""
+        return False
+
+    @property
+    def is_outcome(self) -> bool:
+        """Is this node an outcome?"""
+        return self._outcome
+
+    @property
+    def is_intermediary(self) -> bool:
+        """Is this node an intermediary?"""
+        return not self._outcome

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -1,8 +1,9 @@
 """Graph nodes."""
 
 from __future__ import annotations
-from typing import Protocol, runtime_checkable
+
 from abc import abstractproperty
+from typing import Protocol, runtime_checkable
 
 
 class DistributionFamily:  # TODO: import from elsewhere once it exists
@@ -34,7 +35,7 @@ class Node(Protocol):
         """Is this node an intermediary?"""
 
 
-class RootDistributionNode(object):
+class RootDistributionNode:
     """A root node containing a distribution family."""
 
     def __init__(
@@ -72,7 +73,7 @@ class RootDistributionNode(object):
         return False
 
 
-class DistributionNode(object):
+class DistributionNode:
     """A node containing a distribution family that depends on its parents."""
 
     def __init__(

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -1,0 +1,74 @@
+"""Graph nodes."""
+
+from __future__ import annotations
+from typing import Protocol, runtime_checkable
+from abc import abstractproperty
+
+root_node_index = 0
+
+
+class DistributionFamily:  # TODO: import from elsewhere once it exists
+    """Placeholder class."""
+
+
+class Distribution:  # TODO: import from elsewhere once it exists
+    """Placeholder class."""
+
+
+@runtime_checkable
+class Node(Protocol):
+    """An abstract node in a graph."""
+
+    @abstractproperty
+    def label(self) -> str:
+        """The label of the node."""
+
+    @abstractproperty
+    def is_root(self) -> bool:
+        """Is this node a root?"""
+
+    @abstractproperty
+    def is_outcome(self) -> bool:
+        """Is this node an outcome?"""
+
+    @abstractproperty
+    def is_intermediary(self) -> bool:
+        """Is this node an intermediary?"""
+
+
+class RootDistributionNode(object):
+    """A root node containing a distribution family."""
+
+    def __init__(
+        self, family: DistributionFamily, label: str = None, is_outcome: bool = False
+    ):
+        """Initialise the node."""
+        global root_node_index
+        self._dfamily = family
+
+        if label is None:
+            self._label = f"RootNode{root_node_index}"
+            root_node_index += 1
+        else:
+            self._label = label
+        self._outcome = is_outcome
+
+    @property
+    def label(self) -> str:
+        """The label of the node."""
+        return self._label
+
+    @property
+    def is_root(self) -> bool:
+        """Is this node a root?"""
+        return True
+
+    @property
+    def is_outcome(self) -> bool:
+        """Is this node an outcome?"""
+        return self._outcome
+
+    @property
+    def is_intermediary(self) -> bool:
+        """Is this node an intermediary?"""
+        return False

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -6,11 +6,11 @@ from abc import abstractproperty
 from typing import Protocol, runtime_checkable
 
 
-class DistributionFamily:  # TODO: import from elsewhere once it exists
+class DistributionFamily:
     """Placeholder class."""
 
 
-class Distribution:  # TODO: import from elsewhere once it exists
+class Distribution:
     """Placeholder class."""
 
 
@@ -24,15 +24,15 @@ class Node(Protocol):
 
     @abstractproperty
     def is_root(self) -> bool:
-        """Is this node a root?"""
+        """Identify if the node is a root."""
 
     @abstractproperty
     def is_outcome(self) -> bool:
-        """Is this node an outcome?"""
+        """Identify if the node is an outcome."""
 
     @abstractproperty
     def is_intermediary(self) -> bool:
-        """Is this node an intermediary?"""
+        """Identify if the node is an intermediary."""
 
 
 class RootDistributionNode:
@@ -42,14 +42,16 @@ class RootDistributionNode:
         self,
         family: DistributionFamily,
         label: str,
+        *,
         is_outcome: bool = False,
-    ):
+    ) -> None:
         """Initialise the node."""
         self._dfamily = family
         self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:
+        """Representation."""
         return f'RootDistributionNode("{self._label}")'
 
     @property
@@ -59,17 +61,17 @@ class RootDistributionNode:
 
     @property
     def is_root(self) -> bool:
-        """Is this node a root?"""
+        """Identify if the node is a root."""
         return True
 
     @property
     def is_outcome(self) -> bool:
-        """Is this node an outcome?"""
+        """Identify if the node is an outcome."""
         return self._outcome
 
     @property
     def is_intermediary(self) -> bool:
-        """Is this node an intermediary?"""
+        """Identify if the node is an intermediary."""
         return False
 
 
@@ -80,14 +82,16 @@ class DistributionNode:
         self,
         family: DistributionFamily,
         label: str,
+        *,
         is_outcome: bool = False,
-    ):
+    ) -> None:
         """Initialise the node."""
         self._dfamily = family
         self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:
+        """Representation."""
         return f'DistributionNode("{self._label}")'
 
     @property
@@ -97,15 +101,15 @@ class DistributionNode:
 
     @property
     def is_root(self) -> bool:
-        """Is this node a root?"""
+        """Identify if the node is a root."""
         return False
 
     @property
     def is_outcome(self) -> bool:
-        """Is this node an outcome?"""
+        """Identify if the node is an outcome."""
         return self._outcome
 
     @property
     def is_intermediary(self) -> bool:
-        """Is this node an intermediary?"""
+        """Identify if the node is an intermediary."""
         return not self._outcome

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 from abc import abstractproperty
 
-dnode_index = 0
-rnode_index = 0
-
 
 class DistributionFamily:  # TODO: import from elsewhere once it exists
     """Placeholder class."""
@@ -43,18 +40,12 @@ class RootDistributionNode(object):
     def __init__(
         self,
         family: DistributionFamily,
-        label: str | None = None,
+        label: str,
         is_outcome: bool = False,
     ):
         """Initialise the node."""
-        global rnode_index
         self._dfamily = family
-
-        if label is None:
-            self._label = f"RootDistributionNode{rnode_index}"
-            rnode_index += 1
-        else:
-            self._label = label
+        self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:
@@ -87,18 +78,12 @@ class DistributionNode(object):
     def __init__(
         self,
         family: DistributionFamily,
-        label: str | None = None,
+        label: str,
         is_outcome: bool = False,
     ):
         """Initialise the node."""
-        global dnode_index
         self._dfamily = family
-
-        if label is None:
-            self._label = f"DistributionNode{dnode_index}"
-            dnode_index += 1
-        else:
-            self._label = label
+        self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import abstractproperty
+from abc import abstractmethod
 from typing import Protocol, runtime_checkable
 
 
@@ -18,21 +18,20 @@ class Distribution:
 class Node(Protocol):
     """An abstract node in a graph."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def label(self) -> str:
         """The label of the node."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_root(self) -> bool:
         """Identify if the node is a root."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_outcome(self) -> bool:
         """Identify if the node is an outcome."""
-
-    @abstractproperty
-    def is_intermediary(self) -> bool:
-        """Identify if the node is an intermediary."""
 
 
 class RootDistributionNode:
@@ -69,11 +68,6 @@ class RootDistributionNode:
         """Identify if the node is an outcome."""
         return self._outcome
 
-    @property
-    def is_intermediary(self) -> bool:
-        """Identify if the node is an intermediary."""
-        return False
-
 
 class DistributionNode:
     """A node containing a distribution family that depends on its parents."""
@@ -108,8 +102,3 @@ class DistributionNode:
     def is_outcome(self) -> bool:
         """Identify if the node is an outcome."""
         return self._outcome
-
-    @property
-    def is_intermediary(self) -> bool:
-        """Identify if the node is an intermediary."""
-        return not self._outcome

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -41,7 +41,10 @@ class RootDistributionNode(object):
     """A root node containing a distribution family."""
 
     def __init__(
-        self, family: DistributionFamily, label: str | None = None, is_outcome: bool = False
+        self,
+        family: DistributionFamily,
+        label: str | None = None,
+        is_outcome: bool = False,
     ):
         """Initialise the node."""
         global rnode_index
@@ -53,6 +56,9 @@ class RootDistributionNode(object):
         else:
             self._label = label
         self._outcome = is_outcome
+
+    def __repr__(self) -> str:
+        return f'RootDistributionNode("{self._label}")'
 
     @property
     def label(self) -> str:
@@ -79,7 +85,10 @@ class DistributionNode(object):
     """A node containing a distribution family that depends on its parents."""
 
     def __init__(
-        self, family: DistributionFamily, label: str | None = None, is_outcome: bool = False
+        self,
+        family: DistributionFamily,
+        label: str | None = None,
+        is_outcome: bool = False,
     ):
         """Initialise the node."""
         global dnode_index
@@ -91,6 +100,9 @@ class DistributionNode(object):
         else:
             self._label = label
         self._outcome = is_outcome
+
+    def __repr__(self) -> str:
+        return f'DistributionNode("{self._label}")'
 
     @property
     def label(self) -> str:

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -41,7 +41,7 @@ class RootDistributionNode(object):
     """A root node containing a distribution family."""
 
     def __init__(
-        self, family: DistributionFamily, label: str = None, is_outcome: bool = False
+        self, family: DistributionFamily, label: str | None = None, is_outcome: bool = False
     ):
         """Initialise the node."""
         global rnode_index
@@ -79,7 +79,7 @@ class DistributionNode(object):
     """A node containing a distribution family that depends on its parents."""
 
     def __init__(
-        self, family: DistributionFamily, label: str = None, is_outcome: bool = False
+        self, family: DistributionFamily, label: str | None = None, is_outcome: bool = False
     ):
         """Initialise the node."""
         global dnode_index

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,6 +1,0 @@
-"""An example set of tests."""
-
-
-def test_stupid_example() -> None:
-    """Test is merely a placeholder."""
-    assert True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -6,12 +6,15 @@ def test_root_distribution_node_label():
     node = causalprog.graph.RootDistributionNode(family)
     node2 = causalprog.graph.RootDistributionNode(family)
     node3 = causalprog.graph.RootDistributionNode(family, "Y")
+    node4 = causalprog.graph.DistributionNode(family)
     node_copy = node
 
     assert node.label == node_copy.label
     assert node.label != node2.label
     assert node.label != node3.label
+    assert node.label != node4.label
 
     assert isinstance(node, causalprog.graph.node.Node)
     assert isinstance(node2, causalprog.graph.node.Node)
     assert isinstance(node3, causalprog.graph.node.Node)
+    assert isinstance(node4, causalprog.graph.node.Node)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,5 @@
 import causalprog
+import networkx as nx
 
 
 def test_root_distribution_node_label():
@@ -18,3 +19,20 @@ def test_root_distribution_node_label():
     assert isinstance(node2, causalprog.graph.node.Node)
     assert isinstance(node3, causalprog.graph.node.Node)
     assert isinstance(node4, causalprog.graph.node.Node)
+
+
+def test_simple_graph():
+    family = causalprog.graph.node.DistributionFamily()
+    n_x = causalprog.graph.RootDistributionNode(family, "N_X")
+    n_m = causalprog.graph.RootDistributionNode(family, "N_M")
+    u_y = causalprog.graph.RootDistributionNode(family, "U_Y")
+    x = causalprog.graph.DistributionNode(family, "X")
+    m = causalprog.graph.DistributionNode(family, "M")
+    y = causalprog.graph.DistributionNode(family, "Y")
+
+    nx_graph = nx.Graph()
+    nx_graph.add_edges_from([[n_x, x], [n_m, m], [u_y, y], [x, m], [m, y]])
+
+    graph = causalprog.graph.Graph(nx_graph)
+
+    assert 1 == 0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,17 @@
+import causalprog
+
+
+def test_root_distribution_node_label():
+    family = causalprog.graph.node.DistributionFamily()
+    node = causalprog.graph.RootDistributionNode(family)
+    node2 = causalprog.graph.RootDistributionNode(family)
+    node3 = causalprog.graph.RootDistributionNode(family, "Y")
+    node_copy = node
+
+    assert node.label == node_copy.label
+    assert node.label != node2.label
+    assert node.label != node3.label
+
+    assert isinstance(node, causalprog.graph.node.Node)
+    assert isinstance(node2, causalprog.graph.node.Node)
+    assert isinstance(node3, causalprog.graph.node.Node)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,10 +4,10 @@ import networkx as nx
 
 def test_root_distribution_node_label():
     family = causalprog.graph.node.DistributionFamily()
-    node = causalprog.graph.RootDistributionNode(family)
-    node2 = causalprog.graph.RootDistributionNode(family)
+    node = causalprog.graph.RootDistributionNode(family, "N0")
+    node2 = causalprog.graph.RootDistributionNode(family, "N1")
     node3 = causalprog.graph.RootDistributionNode(family, "Y")
-    node4 = causalprog.graph.DistributionNode(family)
+    node4 = causalprog.graph.DistributionNode(family, "N4")
     node_copy = node
 
     assert node.label == node_copy.label
@@ -33,7 +33,6 @@ def test_simple_graph():
     nx_graph = nx.Graph()
     nx_graph.add_edges_from([[n_x, x], [n_m, m], [u_y, y], [x, m], [m, y]])
 
-    graph = causalprog.graph.Graph(nx_graph)
-    graph2 = causalprog.graph.Graph(nx_graph)
+    graph = causalprog.graph.Graph(nx_graph, "G0")
 
-    assert graph.label != graph2.label
+    assert graph.label == "G0"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,5 +1,6 @@
-import causalprog
 import networkx as nx
+
+import causalprog
 
 
 def test_root_distribution_node_label():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -28,11 +28,12 @@ def test_simple_graph():
     u_y = causalprog.graph.RootDistributionNode(family, "U_Y")
     x = causalprog.graph.DistributionNode(family, "X")
     m = causalprog.graph.DistributionNode(family, "M")
-    y = causalprog.graph.DistributionNode(family, "Y")
+    y = causalprog.graph.DistributionNode(family, "Y", is_outcome=True)
 
     nx_graph = nx.Graph()
     nx_graph.add_edges_from([[n_x, x], [n_m, m], [u_y, y], [x, m], [m, y]])
 
     graph = causalprog.graph.Graph(nx_graph)
+    graph2 = causalprog.graph.Graph(nx_graph)
 
-    assert 1 == 0
+    assert graph.label != graph2.label

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,9 +1,12 @@
+"""Tests for graph module."""
+
 import networkx as nx
 
 import causalprog
 
 
-def test_root_distribution_node_label():
+def test_label2() -> None:
+    """Test nodes."""
     family = causalprog.graph.node.DistributionFamily()
     node = causalprog.graph.RootDistributionNode(family, "N0")
     node2 = causalprog.graph.RootDistributionNode(family, "N1")
@@ -22,7 +25,8 @@ def test_root_distribution_node_label():
     assert isinstance(node4, causalprog.graph.node.Node)
 
 
-def test_simple_graph():
+def test_simple_graph() -> None:
+    """Test a simple graph."""
     family = causalprog.graph.node.DistributionFamily()
     n_x = causalprog.graph.RootDistributionNode(family, "N_X")
     n_m = causalprog.graph.RootDistributionNode(family, "N_M")


### PR DESCRIPTION
Progress towards #3 

Add:

- `Node` protocol that defined the interface a node must have
- `RootDistributionNode` for nodes with no parents
- `DistributionNode` for nodes with parents
- placeholder classes `Distribution` and `DistributionFamily` to be replaced later
- `Graph` that wraps a networkx graph

I've opened #7 with ideas for how to make a nicer graph building interface on top of these data structures.