### PR TITLE
allow unused imports in __init__ files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,11 @@ lint.ignore = [
     "D417", # argument description in docstring (unreliable)
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
 ]
-lint.per-file-ignores = {"tests*" = [
+lint.per-file-ignores = {"__init__.py" = [
+    "F401", # Unused import
+], "tests*" = [
     "INP001", # File is part of an implicit namespace package.
     "S101", # Use of `assert` detected
-], "__init__.py" = [
-    "F401", # Unused import
 ]}
 lint.select = [
     "ALL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,15 +83,12 @@ lint.ignore = [
     "D417", # argument description in docstring (unreliable)
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
 ]
-lint.per-file-ignores = {
-    "tests*" = [
-        "INP001", # File is part of an implicit namespace package.
-        "S101", # Use of `assert` detected
-    ],
-    "__init__.py": [
-        "F401", # Unused import
-    ]
-}
+lint.per-file-ignores = {"tests*" = [
+    "INP001", # File is part of an implicit namespace package.
+    "S101", # Use of `assert` detected
+], "__init__.py" = [
+    "F401", # Unused import
+]}
 lint.select = [
     "ALL",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,15 @@ lint.ignore = [
     "D417", # argument description in docstring (unreliable)
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
 ]
-lint.per-file-ignores = {"tests*" = [
-    "INP001", # File is part of an implicit namespace package.
-    "S101", # Use of `assert` detected
-]}
+lint.per-file-ignores = {
+    "tests*" = [
+        "INP001", # File is part of an implicit namespace package.
+        "S101", # Use of `assert` detected
+    ],
+    "__init__.py": [
+        "F401", # Unused import
+    ]
+}
 lint.select = [
     "ALL",
 ]

--- a/src/causalprog/__init__.py
+++ b/src/causalprog/__init__.py
@@ -1,6 +1,6 @@
 """causalprog package."""
 
-from ._version import __version__  # noqa: F401
+from ._version import __version__
 
 
 def example_function(argument: str, keyword_argument: str = "default") -> str:


### PR DESCRIPTION
Having to put `# noqa: F401` by all unused imports in __init__.py feels over the top to me