### PR TITLE
Ruff & mypy linting rules.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-    "setuptools",
-    "setuptools-scm",
-]
+requires = ["setuptools", "setuptools-scm"]
 
 [project]
 authors = [
@@ -18,14 +15,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = [
-]
+dependencies = []
 description = "A Python package for causal modelling and inference with stochastic causal programming"
-dynamic = [
-    "version",
-]
-keywords = [
-]
+dynamic = ["version"]
+keywords = []
 name = "causalprog"
 optional-dependencies = {dev = [
     "build",
@@ -51,32 +44,23 @@ urls.homepage = "https://github.com/UCL/causalprog"
 
 [tool.coverage]
 report = {sort = "cover"}
-run = {branch = true, parallel = true, source = [
-    "causalprog",
-]}
-paths.source = [
-    "src",
-    ".tox*/*/lib/python*/site-packages",
-]
+run = {branch = true, parallel = true, source = ["causalprog"]}
+paths.source = ["src", ".tox*/*/lib/python*/site-packages"]
 
 [tool.mypy]
+exclude = ["tests"]
 explicit_package_bases = true
 
 [tool.pytest.ini_options]
-addopts = [
-    "--color=yes",
-    "--import-mode=importlib",
-    "--verbose",
-]
-testpaths = [
-    "tests",
-]
+addopts = ["--color=yes", "--import-mode=importlib", "--verbose"]
+testpaths = ["tests"]
 
 [tool.ruff]
 fix = true
 force-exclude = true
 lint.ignore = [
     "COM812", # trailing commas (ruff-format recommended)
+    "D105", # missing docstrings on magic (dunder) methods
     "D203", # no-blank-line-before-class
     "D212", # multi-line-summary-first-line
     "D407", # removed dashes lines under sections
@@ -86,19 +70,15 @@ lint.ignore = [
 lint.per-file-ignores = {"__init__.py" = [
     "F401", # Unused import
 ], "tests*" = [
+    "ANN",
+    "D",
     "INP001", # File is part of an implicit namespace package.
     "S101", # Use of `assert` detected
 ]}
-lint.select = [
-    "ALL",
-]
-lint.isort.known-first-party = [
-    "causalprog",
-]
+lint.select = ["ALL"]
+lint.isort.known-first-party = ["causalprog"]
 lint.mccabe.max-complexity = 18
-lint.pep8-naming.classmethod-decorators = [
-    "classmethod",
-]
+lint.pep8-naming.classmethod-decorators = ["classmethod"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
@@ -114,11 +94,7 @@ overrides."tool.tox.env.docs.commands".inline_arrays = false
 overrides."tool.tox.env_run_base.commands".inline_arrays = false
 
 [tool.tox]
-env_list = [
-    "py311",
-    "py312",
-    "py313",
-]
+env_list = ["py311", "py312", "py313"]
 env_run_base = {commands = [
     [
         "pytest",
@@ -128,15 +104,7 @@ env_run_base = {commands = [
 ], extras = [
     "test",
 ]}
-env.docs = {commands = [
-    [
-        "mkdocs",
-        "build",
-        "--strict",
-    ],
-], extras = [
-    "docs",
-]}
+env.docs = {commands = [["mkdocs", "build", "--strict"]], extras = ["docs"]}
 gh.python."3.11" = ["py311"]
 gh.python."3.12" = ["py312"]
 gh.python."3.13" = ["py313"]


### PR DESCRIPTION
Adds additional rules to the ignore list as per internal Slack suggestions:

- `D105` missing docstrings on magic (dunder) methods - can potentially see the value in having such docstrings in some cases but don't think it should be required as typically their behaviour is obvious and function signature (and so interpretation of arguments) fixed by interface they are implementing
- `ANN` in tests
- `D` rules in tests

Also have added `exclude = ["tests"]` to the `tool.mypy` config section in the `pyproject.toml`, for the same reasons as `ANN` has been ignored.