### PR TITLE
ABC submodule with `Labelled` mixin

### DIFF
--- a/src/causalprog/_abc/__init__.py
+++ b/src/causalprog/_abc/__init__.py
@@ -1,0 +1,1 @@
+"""Abstract Base Classes (ABCs) for ``causalprog`` package."""

--- a/src/causalprog/_abc/labelled.py
+++ b/src/causalprog/_abc/labelled.py
@@ -1,4 +1,7 @@
-class Labelled:
+from abc import ABC
+
+
+class Labelled(ABC):
     """
     ABC for objects that carry a label. This class can be used as a MixIn.
 
@@ -8,9 +11,10 @@ class Labelled:
     ``label`` property of the class.
     """
 
+    __slots__ = ("_label",)
     _label: str
 
-    def __init__(self, label: str) -> None:
+    def __init__(self, *, label: str) -> None:
         self._label = str(label)
 
     @property

--- a/src/causalprog/_abc/labelled.py
+++ b/src/causalprog/_abc/labelled.py
@@ -1,0 +1,19 @@
+class Labelled:
+    """
+    ABC for objects that carry a label. This class can be used as a MixIn.
+
+    Objects must be passed an explicit ``label`` parameter on instantiation,
+    which provides a name for the object. This value is stored in the
+    private ``_label`` attribute, and is only intended to be accessed via the
+    ``label`` property of the class.
+    """
+
+    _label: str
+
+    def __init__(self, label: str) -> None:
+        self._label = str(label)
+
+    @property
+    def label(self) -> str:
+        """Label of this object."""
+        return self._label

--- a/src/causalprog/_abc/labelled.py
+++ b/src/causalprog/_abc/labelled.py
@@ -14,10 +14,10 @@ class Labelled(ABC):
     __slots__ = ("_label",)
     _label: str
 
-    def __init__(self, *, label: str) -> None:
-        self._label = str(label)
-
     @property
     def label(self) -> str:
         """Label of this object."""
         return self._label
+
+    def __init__(self, *, label: str) -> None:
+        self._label = str(label)

--- a/src/causalprog/distribution/base.py
+++ b/src/causalprog/distribution/base.py
@@ -5,6 +5,7 @@ from typing import Generic, TypeVar
 
 from numpy.typing import ArrayLike
 
+from causalprog._abc.labelled import Labelled
 from causalprog.utils.translator import Translator
 
 SupportsRNG = TypeVar("SupportsRNG")
@@ -30,7 +31,7 @@ class SampleTranslator(Translator):
         return {"rng_key", "sample_shape"}
 
 
-class Distribution(Generic[SupportsSampling]):
+class Distribution(Generic[SupportsSampling], Labelled):
     """A (backend-agnostic) distribution that can be sampled from."""
 
     _dist: SupportsSampling
@@ -45,6 +46,8 @@ class Distribution(Generic[SupportsSampling]):
         self,
         backend_distribution: SupportsSampling,
         backend_translator: SampleTranslator | None = None,
+        *,
+        label: str = "Distribution",
     ) -> None:
         """
         Create a new Distribution.
@@ -56,6 +59,8 @@ class Distribution(Generic[SupportsSampling]):
                 sampling function to frontend arguments.
 
         """
+        super().__init__(label=label)
+
         self._dist = backend_distribution
 
         # Setup sampling calls, and perform one-time check for compatibility

--- a/src/causalprog/distribution/family.py
+++ b/src/causalprog/distribution/family.py
@@ -5,6 +5,7 @@ from typing import Generic, TypeVar
 
 from numpy.typing import ArrayLike
 
+from causalprog._abc.labelled import Labelled
 from causalprog.distribution.base import Distribution, SupportsSampling
 from causalprog.utils.translator import Translator
 
@@ -13,7 +14,7 @@ CreatesDistribution = TypeVar(
 )
 
 
-class DistributionFamily(Generic[CreatesDistribution]):
+class DistributionFamily(Generic[CreatesDistribution], Labelled):
     r"""
     A family of ``Distributions``, that share the same parameters.
 
@@ -39,13 +40,16 @@ class DistributionFamily(Generic[CreatesDistribution]):
     def _member(self) -> Callable[..., Distribution]:
         """Constructor method for family members, given parameters."""
         return lambda *parameters: Distribution(
-            self._family(*parameters), backend_translator=self._family_translator
+            self._family(*parameters),
+            backend_translator=self._family_translator,
         )
 
     def __init__(
         self,
         backend_family: CreatesDistribution,
         backend_translator: Translator | None = None,
+        *,
+        family_name: str = "DistributionFamily",
     ) -> None:
         """
         Create a new family of distributions.
@@ -58,6 +62,8 @@ class DistributionFamily(Generic[CreatesDistribution]):
                 passed to the ``Distribution`` constructor.
 
         """
+        super().__init__(label=family_name)
+
         self._family = backend_family
         self._family_translator = backend_translator
 

--- a/src/causalprog/distribution/normal.py
+++ b/src/causalprog/distribution/normal.py
@@ -58,7 +58,7 @@ class Normal(Distribution):
             cov (ArrayCompatible): Matrix of covariates, $\Sigma$.
 
         """
-        super().__init__(_Normal(mean, cov))
+        super().__init__(_Normal(mean, cov), label=f"({mean.ndim}-dim) Normal")
 
 
 class NormalFamily(DistributionFamily):
@@ -74,7 +74,7 @@ class NormalFamily(DistributionFamily):
 
     def __init__(self) -> None:
         """Create a family of normal distributions."""
-        super().__init__(Normal)
+        super().__init__(Normal, family_name="Normal")
 
     def construct(self, mean: ArrayCompatible, cov: ArrayCompatible) -> Normal:
         r"""

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -2,20 +2,22 @@
 
 import networkx as nx
 
+from causalprog._abc.labelled import Labelled
+
 from .node import Node
 
 
-class Graph:
+class Graph(Labelled):
     """A directed acyclic graph that represents a causality tree."""
 
     def __init__(self, graph: nx.Graph, label: str) -> None:
         """Initialise a graph from a NetworkX graph."""
+        super().__init__(label=label)
+
         for node in graph.nodes:
             if not isinstance(node, Node):
                 msg = f"Invalid node: {node}"
                 raise TypeError(msg)
-
-        self._label = label
 
         self._graph = graph.copy()
         self._nodes = list(graph.nodes())
@@ -29,8 +31,3 @@ class Graph:
             msg = "Cannot yet create graph with multiple outcome nodes"
             raise ValueError(msg)
         self._outcome = outcomes[0]
-
-    @property
-    def label(self) -> str:
-        """The label of the graph."""
-        return self._label

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Protocol, runtime_checkable
 
+from causalprog._abc.labelled import Labelled
+
 
 class DistributionFamily:
     """Placeholder class."""
@@ -34,7 +36,7 @@ class Node(Protocol):
         """Identify if the node is an outcome."""
 
 
-class RootDistributionNode:
+class RootDistributionNode(Labelled):
     """A root node containing a distribution family."""
 
     def __init__(
@@ -45,18 +47,14 @@ class RootDistributionNode:
         is_outcome: bool = False,
     ) -> None:
         """Initialise the node."""
+        super().__init__(label=label)
+
         self._dfamily = family
-        self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:
         """Representation."""
         return f'RootDistributionNode("{self._label}")'
-
-    @property
-    def label(self) -> str:
-        """The label of the node."""
-        return self._label
 
     @property
     def is_root(self) -> bool:
@@ -69,7 +67,7 @@ class RootDistributionNode:
         return self._outcome
 
 
-class DistributionNode:
+class DistributionNode(Labelled):
     """A node containing a distribution family that depends on its parents."""
 
     def __init__(
@@ -80,18 +78,14 @@ class DistributionNode:
         is_outcome: bool = False,
     ) -> None:
         """Initialise the node."""
+        super().__init__(label=label)
+
         self._dfamily = family
-        self._label = label
         self._outcome = is_outcome
 
     def __repr__(self) -> str:
         """Representation."""
         return f'DistributionNode("{self._label}")'
-
-    @property
-    def label(self) -> str:
-        """The label of the node."""
-        return self._label
 
     @property
     def is_root(self) -> bool:


### PR DESCRIPTION
Resolves #11 

Adds a (hidden) abstract base class submodule, which for now just includes a `Labelled` mix-in class that provides a `label` property, which accesses a private `_label` attribute.

`Graph`, `(Root)DistributionNode` now use this mix-in rather than redefining the property, and  `Distribution` and `DistributionFamily` now use this mixin.

Mainly opening this PR since I want to also create an abstract base class for objects that need to be backend-agnostic, as that's currently [causing me headaches on this branch](https://github.com/UCL/causalprog/tree/wgraham/argument-mashing). Figured I might as well slot this one in at the same time (with the same file/folder structure to avoid later conflicts).