### PR TITLE
Enable mathjax in mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,8 @@ nav:
 
 markdown_extensions:
   - pymdownx.tasklist
+  - pymdownx.arithmatex:
+      generic: true
 
 plugins:
   - search
@@ -61,3 +63,7 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: "https://github.com/UCL"
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Closes #20, we now have working `MathJax` syntax in our docstrings.