### PR TITLE
Backend-agnostic ABC

### DIFF
--- a/src/causalprog/_abc/backend_agnostic.py
+++ b/src/causalprog/_abc/backend_agnostic.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+Backend = TypeVar("Backend")
+
+
+class BackendAgnostic(ABC, Generic[Backend]):
+    """A frontend object that must be backend-agnostic."""
+
+    __slots__ = ("_backend_obj",)
+    _backend_obj: Backend
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        """Fallback on the backend object a frontend method isn't found."""
+        if name in self._frontend_provides and hasattr(self._backend_obj, name):
+            return getattr(self._backend_obj, name)
+        msg = f"{self} has no attribute {name}."
+        raise AttributeError(msg)
+
+    def __init__(self, *, backend: Backend) -> None:
+        self._backend_obj = backend
+
+    @property
+    @abstractmethod
+    def _frontend_provides(self) -> tuple[str, ...]:
+        """Methods that an instance of this class must provide."""
+
+    @property
+    def _missing_methods(self) -> set[str]:
+        """Return the names of frontend methods that are missing."""
+        return {attr for attr in self._frontend_provides if not hasattr(self, attr)}
+
+    def get_backend(self) -> Backend:
+        """Access to the backend object."""
+        return self._backend_obj
+
+    def validate(self) -> None:
+        """
+        Determine if all expected frontend methods are provided.
+
+        Raises:
+            AttributeError: If frontend methods are not present.
+
+        """
+        if len(self._missing_methods) != 0:
+            raise AttributeError(
+                "Missing frontend methods: " + ", ".join(self._missing_methods)
+            )

--- a/tests/test__abc/test_backend_agnostic.py
+++ b/tests/test__abc/test_backend_agnostic.py
@@ -68,3 +68,5 @@ def test_method_discovery(backend: object, expected_missing: set[str]) -> None:
             match=re.escape("Missing frontend methods: " + ", ".join(expected_missing)),
         ):
             obj.validate()
+    else:
+        obj.validate()

--- a/tests/test__abc/test_backend_agnostic.py
+++ b/tests/test__abc/test_backend_agnostic.py
@@ -61,7 +61,7 @@ def test_method_discovery(backend: object, expected_missing: set[str]) -> None:
     obj = BA(backend=backend)
     assert obj.get_backend() is backend
 
-    assert obj._missing_methods == expected_missing  # noqa: SLF001
+    assert obj._missing_attrs == expected_missing  # noqa: SLF001
     if len(expected_missing) != 0:
         with pytest.raises(
             AttributeError,

--- a/tests/test__abc/test_backend_agnostic.py
+++ b/tests/test__abc/test_backend_agnostic.py
@@ -1,0 +1,70 @@
+import re
+
+import pytest
+
+from causalprog._abc.backend_agnostic import BackendAgnostic
+
+
+class OneMethodBackend:
+    def method1(self) -> None:
+        return
+
+
+class TwoMethodBackend(OneMethodBackend):
+    def method2(self) -> None:
+        return
+
+
+class ThreeMethodBackend(TwoMethodBackend):
+    def method3(self) -> None:
+        return
+
+
+class BA(BackendAgnostic):
+    """
+    Designed to test the abstract ``BackendAgnostic`` class.
+
+    Instances take ``*methods`` as an argument, which has the effect of setting
+    ``self.method`` to be a function that returns ``True`` for each ``method`` in
+    ``*methods``.
+    """
+
+    @property
+    def _frontend_provides(self) -> tuple[str, ...]:
+        return (
+            "method1",
+            "method2",
+        )
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected_missing"),
+    [
+        pytest.param(
+            TwoMethodBackend(),
+            set(),
+            id="All methods defined.",
+        ),
+        pytest.param(
+            ThreeMethodBackend(),
+            set(),
+            id="Additional methods defined.",
+        ),
+        pytest.param(
+            OneMethodBackend(),
+            {"method2"},
+            id="Missing required method.",
+        ),
+    ],
+)
+def test_method_discovery(backend: object, expected_missing: set[str]) -> None:
+    obj = BA(backend=backend)
+    assert obj.get_backend() is backend
+
+    assert obj._missing_methods == expected_missing  # noqa: SLF001
+    if len(expected_missing) != 0:
+        with pytest.raises(
+            AttributeError,
+            match=re.escape("Missing frontend methods: " + ", ".join(expected_missing)),
+        ):
+            obj.validate()


### PR DESCRIPTION
Concerns #8 |

Adds a base class for backend-agnostic objects that will be needed in the package.

A ``BackendAgnostic`` class is setup such that it must have certain attributes, and a reference to some `_backend_obj` that will actually be doing the heavy-lifting for accessing / computing these attributes. This allows us to define methods on the ``BackendAgnostic`` class that conform to our expected frontend behaviours / syntax, and have these methods translate the arguments provided by the frontend into the arguments that need to be passed to the `_backend_obj`.

The most obvious example of these objects will be `Distribution`s - these are required to have a `sample` method, but different backends (`jax.random`, `distrax`, `numpyro`, etc) have different syntaxes for sampling from their distributions. A ``BackendAgnostic`` distribution necessitates having a `sample` method, but for the different backends it would be implemented differently;

```python

class Distribution(BackendAgnostic):

    @property
    def _frontend_provides(self):
        return ("sample",)

class JaxDistribution(Distribution):

    def sample(self, rng_key, sample_shape):
        return self._backend_obj.sample(rng_key, sample_shape)

class NumPyroDistribution(Distribution):

    def sample(self, rng_key, sample_shape):
        return self._backend_obj.sample(key=rng_key, sample_shape=sample_shape)
```

NOTE: This will be one of several "breakdown" PRs that all-together form #23.

NOTE 2: In light if #24, the `jax`-specific `rng_key`s should eventually be replaced with some backend-agnostic class that accepts a `.split` method.