### PR TITLE
`Graph` can build numpyro model for drawing samples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = ["jax", "networkx", "numpy"]
+dependencies = ["jax", "networkx", "numpy", "numpyro"]
 description = "A Python package for causal modelling and inference with stochastic causal programming"
 dynamic = ["version"]
 keywords = []
@@ -36,7 +36,6 @@ optional-dependencies = {dev = [
 ], test = [
     "distrax",
     "numpy",
-    "numpyro",
     "pytest",
     "pytest-cov",
 ]}

--- a/src/causalprog/graph/graph.py
+++ b/src/causalprog/graph/graph.py
@@ -1,10 +1,12 @@
 """Graph storage."""
 
+from collections.abc import Callable
+
 import networkx as nx
+import numpy.typing as npt
 
 from causalprog._abc.labelled import Labelled
-
-from .node import Node, ParameterNode
+from causalprog.graph.node import DistributionNode, Node, ParameterNode
 
 
 class Graph(Labelled):
@@ -114,11 +116,22 @@ class Graph(Labelled):
 
     @property
     def ordered_nodes(self) -> list[Node]:
-        """Nodes ordered so that each node appears after its dependencies."""
+        """`Node`s ordered so that each node appears after its dependencies."""
         if not nx.is_directed_acyclic_graph(self._graph):
             msg = "Graph is not acyclic."
             raise RuntimeError(msg)
         return list(nx.topological_sort(self._graph))
+
+    @property
+    def ordered_dist_nodes(self) -> list[DistributionNode]:
+        """
+        `DistributionNode`s in dependency order.
+
+        Each `DistributionNode` in the returned list appears after all its
+        dependencies. Order is derived from `self.ordered_nodes`, with the
+        `ParameterNode`s removed.
+        """
+        return [node for node in self.ordered_nodes if not node.is_parameter]
 
     def roots_down_to_outcome(
         self,
@@ -134,3 +147,40 @@ class Graph(Labelled):
         return [
             node for node in self.ordered_nodes if node == outcome or node in ancestors
         ]
+
+    def build_model(self) -> Callable[..., None]:
+        """
+        Return a function that constructs the causal model defined by the Graph.
+
+        The model that is defined by a graph is a function of the parameter values,
+        or in this implementation the values of the `ParameterNode`s. This means that
+        a model can only be specified (and then used to sample from, for example) once
+        values for the `ParameterNode`s have been given. However, each of these models
+        is built in the same way, and all that needs to be done is substitute the new
+        parameter values for the old.
+        """
+
+        def _model(**parameter_values: npt.ArrayLike) -> None:
+            """
+            Create the model corresponding to the graph structure.
+
+            The model created is a function of the values that the `ParameterNode`s in
+            the graph take, which is what must be passed into the model as keyword
+            arguments. Names of the keyword arguments should match the labels of the
+            `ParameterNode`s, and their values should be the values of those parameters.
+            """
+            # Initialise node values for the `ParameterNode`s, which should have been
+            # passed in via the keyword arguments.
+            node_record = dict(parameter_values)
+            # Confirm that all `ParameterNode`s have been assigned a value.
+            for node in self.parameter_nodes:
+                if node.label not in node_record:
+                    msg = f"ParameterNode {node.label} not assigned."
+                    raise KeyError(msg)
+
+            # Build model sequentially, using the node_order to inform the construction
+            # process.
+            for node in self.ordered_dist_nodes:
+                node_record[node.label] = node.create_model_site(**node_record)
+
+        return _model

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -95,11 +95,11 @@ class DistributionNode(Node):
     def __repr__(self) -> str:
         return f'DistributionNode("{self.label}")'
 
-    def create_distribution(self, **dependent_nodes: jax.Array) -> npt.ArrayLike:
+    def create_model_site(self, **dependent_nodes: jax.Array) -> npt.ArrayLike:
         """
-        Create a realisation of the distribution attached to this node.
+        Create a model site for the (conditional) distribution attached to this node.
 
-        `dependent_nodes` contains keyword arguments that maps dependent node names
+        `dependent_nodes` should contain keyword arguments mapping dependent node names
         to the values that those nodes are taking (`ParameterNode`s), or the sampling
         object for those nodes (`DistributionNode`s). These are passed to
         `self._dist` as keyword arguments to construct the sample-able object
@@ -108,7 +108,7 @@ class DistributionNode(Node):
         return numpyro.sample(
             self.label,
             self._dist(
-                {
+                **{
                     native_name: dependent_nodes[node_name]
                     for native_name, node_name in self._parameters.items()
                 }

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 
 import jax
 import numpy as np
+import numpyro
 
 if typing.TYPE_CHECKING:
     import numpy.typing as npt
@@ -93,6 +94,26 @@ class DistributionNode(Node):
 
     def __repr__(self) -> str:
         return f'DistributionNode("{self.label}")'
+
+    def create_distribution(self, **dependent_nodes: jax.Array) -> npt.ArrayLike:
+        """
+        Create a realisation of the distribution attached to this node.
+
+        `dependent_nodes` contains keyword arguments that maps dependent node names
+        to the values that those nodes are taking (`ParameterNode`s), or the sampling
+        object for those nodes (`DistributionNode`s). These are passed to
+        `self._dist` as keyword arguments to construct the sample-able object
+        representing this node.
+        """
+        return numpyro.sample(
+            self.label,
+            self._dist(
+                {
+                    native_name: dependent_nodes[node_name]
+                    for native_name, node_name in self._parameters.items()
+                }
+            ),
+        )
 
 
 class ParameterNode(Node):

--- a/src/causalprog/graph/node.py
+++ b/src/causalprog/graph/node.py
@@ -64,7 +64,16 @@ class DistributionNode(Node):
         constant_parameters: dict[str, float] | None = None,
         is_outcome: bool = False,
     ) -> None:
-        """Initialise."""
+        """
+        Initialise.
+
+        NOTE: As of [#59](https://github.com/UCL/causalprog/pull/59),
+        we will be committing to using Numpyro distributions for the
+        foreseeable future. We will leave the backend-agnostic
+        `DistributionFamily` class here as a type-hint (until it causes
+        mypy issues), however code should only be assumed to work when
+        `distribution` is passed a class from `numpyro.distributions`.
+        """
         self._dist = distribution
         self._constant_parameters = constant_parameters if constant_parameters else {}
         self._parameters = parameters if parameters else {}

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -1,0 +1,165 @@
+import re
+from collections.abc import Callable
+from typing import Any, Concatenate, TypeAlias
+
+import jax
+import numpy as np
+import numpy.typing as npt
+import numpyro
+import pytest
+from numpyro.distributions import Normal
+from numpyro.infer import MCMC, NUTS
+
+from causalprog.graph import DistributionNode, Graph, ParameterNode
+
+# TODO: Refactor into conftest to share with test_node/test_create_model_site.py.
+# Similarly for any other graphs here that are shared... and decorator-fixtures
+MCMCRunner: TypeAlias = Callable[Concatenate[Callable, ...], MCMC]
+
+
+@pytest.fixture(scope="session")
+def mcmc_default_options() -> dict[str, float]:
+    return {"num_warmup": 500, "num_samples": 1000}
+
+
+@pytest.fixture
+def run_nuts_mcmc(
+    rng_key: jax.Array,
+) -> MCMCRunner:
+    def inner(model, *, nuts_kwargs=None, mcmc_kwargs=None) -> MCMC:
+        if not nuts_kwargs:
+            nuts_kwargs = {}
+        if not mcmc_kwargs:
+            mcmc_kwargs = {}
+
+        kernel = NUTS(model, **nuts_kwargs)
+        mcmc = MCMC(kernel, **mcmc_kwargs)
+        mcmc.run(rng_key)
+        return mcmc
+
+    return inner
+
+
+@pytest.fixture
+def two_normal_graph() -> Graph:
+    g = Graph(label="Two Normals")
+
+    mu_x = ParameterNode(label="mu_x")
+    nu_y = ParameterNode(label="nu_y")
+
+    x = DistributionNode(
+        Normal,
+        label="X",
+        parameters={"loc": "mu_x"},
+        constant_parameters={"scale": 1.0},
+    )
+    y = DistributionNode(
+        Normal,
+        label="Y",
+        parameters={"loc": "X", "scale": "nu_y"},
+    )
+    g.add_node(mu_x)
+    g.add_node(nu_y)
+    g.add_edge(mu_x, x)
+    g.add_edge(nu_y, y)
+    g.add_edge(x, y)
+
+    return g
+
+
+@pytest.fixture
+def two_normal_graph_expected_model() -> Callable[..., Callable[[], None]]:
+    """Creates the model that the two_normal_graph should produce."""
+
+    def _inner(mu_x: float, nu_y: float) -> Callable[[], None]:
+        def _model():
+            x = numpyro.sample("X", Normal(loc=mu_x, scale=1.0))
+            numpyro.sample("Y", Normal(loc=x, scale=nu_y))
+
+        return _model
+
+    return _inner
+
+
+def test_model_constructor(
+    two_normal_graph: Graph,
+    two_normal_graph_expected_model: Callable[[float, float], Callable[[], None]],
+    run_nuts_mcmc: MCMCRunner,
+    mcmc_default_options: dict[str, Any],
+    collection_of_parameter_values: tuple[dict[str, npt.ArrayLike], ...] = (
+        {"mu_x": 0.0, "nu_y": 1.0},
+        {"mu_x": 1.0, "nu_y": 2.0},
+    ),
+) -> None:
+    """Test the model_constructor.
+
+    The `Graph.model_constructor` should only need to be invoked once per `Graph`.
+    Though it does need to be "re-invoked" if the `Graph` is edited in any way after
+    calling it previously.
+
+    One the `model_constructor` has been invoked, it returns a function that should
+    be able to construct a model represented by the `Graph`, _given_ values of the
+    `ParameterNode`s to use. This means we should be able to invoke the output of
+    `Graph.model_constructor` multiple times, with different sets of parameters, and
+    each time produce a different realisation of the model.
+
+    We check these properties in the following way:
+    - First, we invoke `two_normal_graph.model_constructor()`, saving the result to
+      the `constructor` variable.
+    - Then, for each collection of parameters, we create a realisation from the
+      `constructor`, by passing in that collection of parameters. We then confirm that
+      this agrees with the explicit model that should have been constructed.
+    """
+    # The model builder only needs to be created once per Graph.
+    constructor = two_normal_graph.model_constructor()
+    assert callable(constructor)
+
+    # Now, we should be able to use each set of parameters to create
+    # realisations of the model.
+    for param_values in collection_of_parameter_values:
+        # Now realise the model with the parameter values we have given
+        realisation = constructor(**param_values)
+        assert callable(realisation)
+
+        # And finally realise the expected model using the same parameter values
+        expected_realisation = two_normal_graph_expected_model(**param_values)  # type: ignore
+
+        # Confirm that the two models are indeed identical.
+        # TODO: Refactor this into a "assert models are equal" method or something.
+        via_model: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+            realisation,
+            mcmc_kwargs=mcmc_default_options,
+        ).get_samples()
+        via_expected: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+            expected_realisation,
+            mcmc_kwargs=mcmc_default_options,
+        ).get_samples()
+
+        for sample_name, samples in via_model.items():
+            assert sample_name in via_expected
+            assert np.allclose(samples, via_expected[sample_name])
+
+
+def test_model_constructor_missing_parameter(
+    two_normal_graph: Graph,
+    parameter_values: dict[str, npt.ArrayLike] = {"mu_x": 0.0},
+    expected_exception: Exception = KeyError("ParameterNode 'nu_y' not assigned"),
+) -> None:
+    """Any models build by a `Graph` will raise a `KeyError` when they are not provided
+    values for all of the `ParameterNode`s, since this prevents the model from being
+    realised.
+
+    We can check for this behaviour by deliberately 'leaving out' one parameter from
+    the `parameter_values` argument, and then attempting to invoke the model function
+    that the `Graph` creates.
+    """
+    # Building the model itself should be OK, since this sets up the model function
+    # which assumes it will be passed values for each parameter.
+    constructor = two_normal_graph.model_constructor()
+
+    # Attempting to construct a model with too few parameters
+    # should now result in an error
+    with pytest.raises(
+        type(expected_exception), match=re.escape(str(expected_exception))
+    ):
+        constructor(**parameter_values)

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -122,7 +122,7 @@ def test_model_constructor(
         assert callable(realisation)
 
         # And finally realise the expected model using the same parameter values
-        expected_realisation = two_normal_graph_expected_model(**param_values)  # type: ignore
+        expected_realisation = two_normal_graph_expected_model(**param_values)  # type: call_args
 
         # Confirm that the two models are indeed identical.
         # TODO: Refactor this into a "assert models are equal" method or something.
@@ -142,8 +142,6 @@ def test_model_constructor(
 
 def test_model_constructor_missing_parameter(
     two_normal_graph: Graph,
-    parameter_values: dict[str, npt.ArrayLike] = {"mu_x": 0.0},
-    expected_exception: Exception = KeyError("ParameterNode 'nu_y' not assigned"),
 ) -> None:
     """Any models build by a `Graph` will raise a `KeyError` when they are not provided
     values for all of the `ParameterNode`s, since this prevents the model from being
@@ -153,6 +151,11 @@ def test_model_constructor_missing_parameter(
     the `parameter_values` argument, and then attempting to invoke the model function
     that the `Graph` creates.
     """
+    # Deliberately leave out the "nu_y" variable.
+    parameter_values = {"mu_x": 0.0}
+    # Which should result in the error below.
+    expected_exception = KeyError("ParameterNode 'nu_y' not assigned")
+
     # Building the model itself should be OK, since this sets up the model function
     # which assumes it will be passed values for each parameter.
     constructor = two_normal_graph.model_constructor()

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -122,7 +122,7 @@ def test_model_constructor(
         assert callable(realisation)
 
         # And finally realise the expected model using the same parameter values
-        expected_realisation = two_normal_graph_expected_model(**param_values)  # type: call_args
+        expected_realisation = two_normal_graph_expected_model(**param_values)  # type: ignore[call-arg]
 
         # Confirm that the two models are indeed identical.
         # TODO: Refactor this into a "assert models are equal" method or something.

--- a/tests/test_node/test_create_distribution.py
+++ b/tests/test_node/test_create_distribution.py
@@ -1,0 +1,110 @@
+import re
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+import jax
+import numpy as np
+import numpy.typing as npt
+import numpyro
+import pytest
+from numpyro.distributions import Normal
+from numpyro.infer import MCMC, NUTS
+
+from causalprog.graph.node import DistributionNode
+
+MCMCRunner: TypeAlias = Callable[[Callable, dict[str, Any], dict[str, Any]], MCMC]
+
+
+@pytest.fixture(scope="session")
+def mcmc_default_options() -> dict[str, float]:
+    return {"num_warmup": 500, "num_samples": 1000}
+
+
+@pytest.fixture
+def run_nuts_mcmc(
+    rng_key: jax.Array,
+) -> MCMCRunner:
+    def inner(model, *, nuts_kwargs=None, mcmc_kwargs=None) -> MCMC:
+        if not nuts_kwargs:
+            nuts_kwargs = {}
+        if not mcmc_kwargs:
+            mcmc_kwargs = {}
+
+        kernel = NUTS(model, **nuts_kwargs)
+        mcmc = MCMC(kernel, **mcmc_kwargs)
+        mcmc.run(rng_key)
+        return mcmc
+
+    return inner
+
+
+@pytest.mark.parametrize(
+    ("node", "dependent_nodes", "identical_model"),
+    [
+        pytest.param(
+            DistributionNode(
+                Normal,
+                label="Normal",
+                constant_parameters={"loc": 0.0, "scale": 1.0},
+            ),
+            # This is not a useless lambda, we need to delay evaluation until inside the
+            # model function.
+            lambda: {},  # noqa: PIE807
+            lambda: numpyro.sample("Normal", Normal(loc=0.0, scale=1.0)),
+            id="Constant parameters only",
+        ),
+        pytest.param(
+            DistributionNode(
+                Normal,
+                label="Normal",
+                parameters={"loc": "mu"},
+                constant_parameters={"scale": 1.0},
+            ),
+            lambda: {"mu": 0.0},
+            lambda: numpyro.sample("Normal", Normal(loc=0.0, scale=1.0)),
+            id="Parameter node dependency",
+        ),
+        pytest.param(
+            DistributionNode(
+                Normal,
+                label="Normal",
+                parameters={"loc": "mu"},
+                constant_parameters={"scale": 1.0},
+            ),
+            lambda: {"mu": numpyro.sample("mu", Normal(0.0, 1.0))},
+            lambda: numpyro.sample(
+                "Normal",
+                Normal(loc=numpyro.sample("mu", Normal(0.0, 1.0)), scale=1.0),
+            ),
+            id="DistributionNode dependency",
+        ),
+        # WRITE ERROR CASES!!
+    ],
+)
+def test_create_distribution(
+    node: DistributionNode,
+    dependent_nodes: Callable[[], dict[str, npt.ArrayLike]],
+    identical_model: Exception | Callable[[], npt.ArrayLike],
+    run_nuts_mcmc: MCMCRunner,
+    mcmc_default_options: dict[str, float],
+) -> None:
+    """Test use and error cases for create_distribution."""
+    # Look to refactor this somehow Will! yield fixture maybe? Or a wrapper function? Or a context (better)...
+    if isinstance(identical_model, Exception):
+        with pytest.raises(
+            type(identical_model), match=re.escape(str(identical_model))
+        ):
+            node.create_distribution(**dependent_nodes)
+    else:
+        via_method: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+            lambda: node.create_distribution(**dependent_nodes()),
+            mcmc_kwargs=mcmc_default_options,
+        ).get_samples()
+        trusted: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+            identical_model,
+            mcmc_kwargs=mcmc_default_options,
+        ).get_samples()
+
+        for sample_name, samples in via_method.items():
+            assert sample_name in trusted
+            assert np.allclose(samples, trusted[sample_name])

--- a/tests/test_node/test_create_model_site.py
+++ b/tests/test_node/test_create_model_site.py
@@ -115,6 +115,7 @@ def test_create_model_site(
         ):
             node.create_model_site(**dependent_nodes())
     else:
+        # TODO: Refactor this into a "assert models are equal" method or something.
         via_method: dict[str, npt.ArrayLike] = run_nuts_mcmc(
             lambda: node.create_model_site(**dependent_nodes()),
             mcmc_kwargs=mcmc_default_options,

--- a/tests/test_node/test_create_model_site.py
+++ b/tests/test_node/test_create_model_site.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Concatenate, TypeAlias
 
 import jax
 import numpy as np
@@ -12,7 +12,7 @@ from numpyro.infer import MCMC, NUTS
 
 from causalprog.graph.node import DistributionNode
 
-MCMCRunner: TypeAlias = Callable[[Callable, dict[str, Any], dict[str, Any]], MCMC]
+MCMCRunner: TypeAlias = Callable[Concatenate[Callable, ...], MCMC]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Works towards #58 |

Important:

- PR makes `numpyro` required by the package.
- PR, for the time being, assumes that we're only using `numpyro.distribution` objects. I haven't changed all the `DistributionFamily` typehints accordingly, since that will cause a lot of PR noise and impact a lot of the tests.

## What Do?

Provided we stick to objects that `numpyro` can handle, we can use it and the graph structure to sequentially construct a model that can then be used in - for example - an MCMC sampler to draw samples for each of the RVs.

Note that by a "model" here, I specifically refer to "a function that takes no arguments, but which defines a number of sites that form a numpyro model". The [introduction to numpyro](https://num.pyro.ai/en/latest/getting_started.html) page makes this slightly more explicit - the "model" created by a `Graph` is the function analogous to the `eight_schools` function defined in the example.

There are multiple layers to this process. Once we have the `Graph`, we know _how to_ construct the model from the nodes, _but_ would require explicit values for the `ParameterNode`s to actually instantiate a model we could sample from. This results in a slightly complex "nested function" structure for the `Graph.model_constructor` method:

- `Graph.model_constructor` itself returns a function, `_model`.
- `_model` takes a number of keyword arguments equal to the number of `ParameterNode`s in the `Graph`. The keyword arguments must share names with the labels of the `ParameterNode`s.
- Invoking `_model(**parameter_values)` returns the "model" as per the above paragraph.

As such, `_model` is effectively now a function of the `ParameterNode`s in the `Graph`, and thus can (hopefully) be used in optimisers. It can, at the very least, be used to draw samples:

(See also `tests/test_graph/test_model_constructor.py` for a working example)
```python
    # The model builder only needs to be created once per Graph.
    constructor = two_normal_graph.model_constructor()
    assert callable(constructor)

    # Now, we should be able to use each set of parameters to create
    # realisations of the model.
    for param_values in collection_of_parameter_values:
        # Now realise the model with the parameter values we have given
        realisation = constructor(**param_values)
        assert callable(realisation)

        # Can now draw samples from our model, for example.
        # run_nuts_mcmc runs an MCMC on the model defined by `realisation`.
        via_model: dict[str, npt.ArrayLike] = run_nuts_mcmc(
            realisation,
            mcmc_kwargs=mcmc_default_options,
        ).get_samples()
```

## Other Notable Changes / Additions

- `DistributionNode`s have been given a `create_model_site` method. Given all their dependencies, (values for the `ParameterNode`s they depend on, and the `numpyro.sample` object for any `DistributionNode`s they depend on), this returns a `numpyro.sample` of the given `DistributionNode`.
- `ParameterNode`s - I believe - will no longer require the `current_value` attribute, since we effectively turn this into an input argument to the `_model` function we obtain from `Graph.model_constructor`. I haven't implemented this change, because again, scope drift.
- `Graph` has gained a `ordered_dist_nodes` property which is just a convenience wrapper for returning the `DistributionNode`s in dependency order, so the `model_constructor` knows which order to build them in.
- Tests have been added for the `DistributionNode.create_model_site` and `Graph.model_constructor` methods. Note that there's some duplication in the tests, but this is mainly because I couldn't find a non-scope-drifting way to get around this duplication. Have opened #62 to track this, and mark it for fixing.

## Considerations

Some things I considered and would like a 2nd opinion on:

- The output of `Graph.model_constructor` has a case for being an instance of a custom class. 
  - Conceptually, this is because after invoking the `model_constructor`, we have left the world of the graph and now have our model to start performing analysis on.
  - It also means that we'll potentially avoid memory-sharing issues down the line (since `model_constructor` has to make references to the `Graph` attributes, which _might_ change if a user wants to recycle instances). 
  - And finally, it would be really helpful for testing and debugging purposes :sweat_smile: As a class instance, we could have easy access to attributes that we currently _don't_ have access to since they're defined as local variables within functions (within functions).
- Have left a bunch of TODOs in the test files in particular. Again, this is mostly so I don't bloat this PR. #62 was opened with a view to fixing these issues in separate PRs. But this does mean the linter is unhappy (`ruff` is a cruel master).