### PR TITLE
Organise the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests status][tests-badge]][tests-link]
 [![Linting status][linting-badge]][linting-link]
 [![Documentation status][documentation-badge]][documentation-link]
-[![License][license-badge]](./LICENSE.md)
+[![License][license-badge]](http://github-pages.ucl.ac.uk/causalprog/LICENSE.md)
 
 <!-- prettier-ignore-start -->
 [tests-badge]:              https://github.com/UCL/causalprog/actions/workflows/tests.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ pytest tests
 
 again from the root of the repository.
 
+For more information about the testing suite, please see [the documentation page](./docs/developers/tests.md).
+
 ### Building documentation
 
 The MkDocs HTML documentation can be built locally by running

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests status][tests-badge]][tests-link]
 [![Linting status][linting-badge]][linting-link]
 [![Documentation status][documentation-badge]][documentation-link]
-[![License][license-badge]](http://github-pages.ucl.ac.uk/causalprog/LICENSE.md)
+[![License][license-badge]](http://github-pages.ucl.ac.uk/causalprog/LICENSE)
 
 <!-- prettier-ignore-start -->
 [tests-badge]:              https://github.com/UCL/causalprog/actions/workflows/tests.yml/badge.svg

--- a/docs/developers/tests.md
+++ b/docs/developers/tests.md
@@ -48,3 +48,10 @@ Our general guidelines for organising unit tests are:
 
 Any integration tests should be placed into the `test_integration` subfolder.
 Again, this directory should contain a single file per integration test.
+
+## Useful fixtures
+
+Some useful fixtures that are included in the `fixtures` directory;
+
+- `ssed` and `rng_key` (`fixtures/general.py`) - sets [the PRNG Key](https://docs.jax.dev/en/latest/_autosummary/jax.random.PRNGKey.html) that should be used across all tests, to ensure repeatability.
+- `raises_context` (`fixtures/general.py`) - can be used to return a `pytest.raises` context that checks for a specific exception, including matching the error message.

--- a/docs/developers/tests.md
+++ b/docs/developers/tests.md
@@ -1,0 +1,50 @@
+# Testing Suite
+
+`causalprog`'s test suite is written using [`pytest`](https://docs.pytest.org/en/stable/).
+The package can be installed with its developer dependencies, including `pytest`, by specifying the `[dev]` optional dependency when installing the package.
+
+## Running the tests
+
+To run the test suite, you will need to clone the `causalprog` repository and then install `causalprog` into your developer environment with the `[dev]` optional dependencies.
+We recommend specifying an editable installation if you intend to make contributions to the package.
+
+```sh
+(causalprog-environment) $ git clone git@github.com:UCL/causalprog.git
+(causalprog-environment) $ cd causalprog
+(causalprog-environment) $ pip install -e .[dev]
+```
+
+You can then run the tests manually inside your developer environment from the root of the repository,
+
+```sh
+(causalprog-environment) $ pytest tests/
+```
+
+Alternatively, tests can be run across all compatible Python versions in isolated environments using [`tox`](https://tox.wiki/en/latest/).
+Running
+
+```sh
+(causalprog-environment) $ tox
+```
+
+in the repository root will do so.
+
+## Organisation of the test suite
+
+The test suite contains a `fixtures` subdirectory, which is loaded as a `pytest` plugin when the tests are run.
+All `pytest.fixture` objects defined inside the `fixtures` subdirectory (and subdirectories therein) are discovered by `pytest`, and available for use by individual tests.
+
+- Fixtures that are shared across multiple test files should be refactored into this folder, being placed into an appropriate file.
+  If possible, include a docstring describing what the fixture does (if it is a method or function) or the instance it defines (if it defines an instance of a class, for example a fixed `Graph` used in multiple tests).
+- Fixtures that are only used by tests within a single file, should be defined in that file rather than the `fixtures` directory.
+
+We favour granularity for the files containing the tests themselves.
+Unit tests are stored starting at the same level as the `fixtures` directory.
+Our general guidelines for organising unit tests are:
+
+- Use subdirectories to group files containing tests by module and class.
+- For each method or function; write all its unit tests inside a single file.
+- Keep to the limit of one method / function being tested per file, except in cases where it is sensible to include closely related methods / functions.
+
+Any integration tests should be placed into the `test_integration` subfolder.
+Again, this directory should contain a single file per integration test.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 <!-- markdownlint-disable MD041 -->
 
-{! include-markdown "../README.md" rewrite-relative-urls=false !}
+{! include-markdown "../README.md" rewrite-relative-urls=true !}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
   - Theory:
       - Mathematical context: theory/mathematical-context.md
       - Simple working example: theory/simple-working-example.md
+  - Developers:
+      - Testing suite: developers/tests.md
   - API reference: api.md
   - License: LICENSE.md
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,15 @@
-import jax.numpy as jnp
-import jax.random as jrn
-import pytest
-from jax._src.basearray import Array
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).parent.resolve()
 
 
-@pytest.fixture
-def seed() -> int:
-    return 0
+def _to_module_string(path: str) -> str:
+    """Convert a file path to a module string."""
+    return path.replace("/", ".").replace("\\", ".").replace(".py", "")
 
 
-@pytest.fixture
-def rng_key(seed: int):
-    return jrn.key(seed)
-
-
-@pytest.fixture
-def n_dim_std_normal(request) -> dict[str, Array]:
-    """
-    Mean and covariance matrix of the n-dimensional standard normal distribution.
-
-    ``request.param`` should be an integer corresponding to the number of dimensions.
-    """
-    n_dims = request.param
-    mean = jnp.array([0.0] * n_dims)
-    cov = jnp.diag(jnp.array([1.0] * n_dims))
-    return {"mean": mean, "cov": cov}
+pytest_plugins = [
+    _to_module_string(fixture.relative_to(_THIS_DIR.parent).as_posix())
+    for fixture in (Path(f"{_THIS_DIR}/fixtures").glob("*.py"))
+    if "__init__" not in str(fixture)
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,6 @@ def _to_module_string(path: str) -> str:
 
 pytest_plugins = [
     _to_module_string(fixture.relative_to(_THIS_DIR.parent).as_posix())
-    for fixture in (Path(f"{_THIS_DIR}/fixtures").glob("*.py"))
+    for fixture in (Path(f"{_THIS_DIR}/fixtures").rglob("*.py"))
     if "__init__" not in str(fixture)
 ]

--- a/tests/fixtures/general.py
+++ b/tests/fixtures/general.py
@@ -1,0 +1,12 @@
+import jax.random as jrn
+import pytest
+
+
+@pytest.fixture
+def seed() -> int:
+    return 0
+
+
+@pytest.fixture
+def rng_key(seed: int):
+    return jrn.key(seed)

--- a/tests/fixtures/general.py
+++ b/tests/fixtures/general.py
@@ -1,9 +1,9 @@
 import re
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 
 import jax.random as jrn
 import pytest
-from _pytest.python_api import RaisesContext
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def rng_key(seed: int):
 
 
 @pytest.fixture(scope="session")
-def raises_context() -> Callable[[Exception], RaisesContext]:
+def raises_context() -> Callable[[Exception], AbstractContextManager]:
     """Wrapper around `pytest.raises` that can be passed an Exception instance.
 
     For a variable containing an `Exception` instance,
@@ -33,7 +33,7 @@ def raises_context() -> Callable[[Exception], RaisesContext]:
     >>> raises_context(expected_exception)
     """
 
-    def _inner(match_error: Exception) -> RaisesContext:
+    def _inner(match_error: Exception) -> AbstractContextManager:
         return pytest.raises(type(match_error), match=re.escape(str(match_error)))
 
     return _inner

--- a/tests/fixtures/general.py
+++ b/tests/fixtures/general.py
@@ -1,5 +1,9 @@
+import re
+from collections.abc import Callable
+
 import jax.random as jrn
 import pytest
+from _pytest.python_api import RaisesContext
 
 
 @pytest.fixture
@@ -10,3 +14,26 @@ def seed() -> int:
 @pytest.fixture
 def rng_key(seed: int):
     return jrn.key(seed)
+
+
+@pytest.fixture(scope="session")
+def raises_context() -> Callable[[Exception], RaisesContext]:
+    """Wrapper around `pytest.raises` that can be passed an Exception instance.
+
+    For a variable containing an `Exception` instance,
+
+    >>> expected_exception = Exception("message")
+
+    the following statements are equivalent:
+
+    >>> pytest.raises(
+    ...     type(expected_exception),
+    ...     match=re.escape(str(expected_exception))
+    ... )
+    >>> raises_context(expected_exception)
+    """
+
+    def _inner(match_error: Exception) -> RaisesContext:
+        return pytest.raises(type(match_error), match=re.escape(str(match_error)))
+
+    return _inner

--- a/tests/fixtures/numpyro/mcmc.py
+++ b/tests/fixtures/numpyro/mcmc.py
@@ -1,0 +1,52 @@
+"""Helper functions for running MCMCs on numpyro models."""
+
+from collections.abc import Callable
+from typing import Concatenate, TypeAlias
+
+import pytest
+from jax import Array
+from numpyro.infer import MCMC, NUTS
+
+MCMCRunner: TypeAlias = Callable[Concatenate[Callable, ...], MCMC]
+
+
+@pytest.fixture(scope="session")
+def mcmc_default_options() -> dict[str, float]:
+    """Default options used when running a numpyro.infer MCMC."""
+    return {"num_warmup": 500, "num_samples": 1000}
+
+
+@pytest.fixture
+def run_nuts_mcmc(
+    rng_key: Array,
+) -> MCMCRunner:
+    """Run an MCMC using a NUTS (No-U-Turns) method.
+
+    run_nuts_mcmc(model) returns the MCMC instance that would result from
+    setting up a NUTS kernel and passing it to numpyro.infer.MCMC.
+    """
+
+    def inner(model, *, nuts_kwargs=None, mcmc_kwargs=None) -> MCMC:
+        if not nuts_kwargs:
+            nuts_kwargs = {}
+        if not mcmc_kwargs:
+            mcmc_kwargs = {}
+
+        kernel = NUTS(model, **nuts_kwargs)
+        mcmc = MCMC(kernel, **mcmc_kwargs)
+        mcmc.run(rng_key)
+        return mcmc
+
+    return inner
+
+
+@pytest.fixture
+def run_default_nuts_mcmc(
+    mcmc_default_options: dict[str, float], run_nuts_mcmc: MCMCRunner
+) -> MCMCRunner:
+    """Run an MCMC using the default options (for tests within the test suite)."""
+
+    def inner(model) -> MCMC:
+        return run_nuts_mcmc(model, mcmc_kwargs=mcmc_default_options)
+
+    return inner

--- a/tests/fixtures/standard_distributions.py
+++ b/tests/fixtures/standard_distributions.py
@@ -1,0 +1,18 @@
+"""Fixture file for quick-creation of standard distributions."""
+
+import jax.numpy as jnp
+import pytest
+from jax import Array
+
+
+@pytest.fixture
+def n_dim_std_normal(request: pytest.FixtureRequest) -> dict[str, Array]:
+    """
+    Mean and covariance matrix of the n-dimensional standard normal distribution.
+
+    ``request.param`` should be an integer corresponding to the number of dimensions.
+    """
+    n_dims = request.param
+    mean = jnp.array([0.0] * n_dims)
+    cov = jnp.diag(jnp.array([1.0] * n_dims))
+    return {"mean": mean, "cov": cov}

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable
 from typing import Any
 
@@ -113,6 +112,7 @@ def test_model_constructor(
 
 def test_model_constructor_missing_parameter(
     two_normal_graph: Graph,
+    raises_context,
 ) -> None:
     """Any models build by a `Graph` will raise a `KeyError` when they are not provided
     values for all of the `ParameterNode`s, since this prevents the model from being
@@ -133,7 +133,5 @@ def test_model_constructor_missing_parameter(
 
     # Attempting to construct a model with too few parameters
     # should now result in an error
-    with pytest.raises(
-        type(expected_exception), match=re.escape(str(expected_exception))
-    ):
+    with raises_context(expected_exception):
         constructor(**parameter_values)

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -1,43 +1,14 @@
 import re
 from collections.abc import Callable
-from typing import Any, Concatenate, TypeAlias
+from typing import Any
 
-import jax
 import numpy as np
 import numpy.typing as npt
 import numpyro
 import pytest
 from numpyro.distributions import Normal
-from numpyro.infer import MCMC, NUTS
 
 from causalprog.graph import DistributionNode, Graph, ParameterNode
-
-# TODO: Refactor into conftest to share with test_node/test_create_model_site.py.
-# Similarly for any other graphs here that are shared... and decorator-fixtures
-MCMCRunner: TypeAlias = Callable[Concatenate[Callable, ...], MCMC]
-
-
-@pytest.fixture(scope="session")
-def mcmc_default_options() -> dict[str, float]:
-    return {"num_warmup": 500, "num_samples": 1000}
-
-
-@pytest.fixture
-def run_nuts_mcmc(
-    rng_key: jax.Array,
-) -> MCMCRunner:
-    def inner(model, *, nuts_kwargs=None, mcmc_kwargs=None) -> MCMC:
-        if not nuts_kwargs:
-            nuts_kwargs = {}
-        if not mcmc_kwargs:
-            mcmc_kwargs = {}
-
-        kernel = NUTS(model, **nuts_kwargs)
-        mcmc = MCMC(kernel, **mcmc_kwargs)
-        mcmc.run(rng_key)
-        return mcmc
-
-    return inner
 
 
 @pytest.fixture
@@ -84,7 +55,7 @@ def two_normal_graph_expected_model() -> Callable[..., Callable[[], None]]:
 def test_model_constructor(
     two_normal_graph: Graph,
     two_normal_graph_expected_model: Callable[[float, float], Callable[[], None]],
-    run_nuts_mcmc: MCMCRunner,
+    run_nuts_mcmc,
     mcmc_default_options: dict[str, Any],
     collection_of_parameter_values: tuple[dict[str, npt.ArrayLike], ...] = (
         {"mu_x": 0.0, "nu_y": 1.0},

--- a/tests/test_graph/test_model_constructor.py
+++ b/tests/test_graph/test_model_constructor.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 from typing import Any
 
-import numpy as np
 import numpy.typing as npt
 import numpyro
 import pytest
@@ -54,6 +53,7 @@ def two_normal_graph_expected_model() -> Callable[..., Callable[[], None]]:
 def test_model_constructor(
     two_normal_graph: Graph,
     two_normal_graph_expected_model: Callable[[float, float], Callable[[], None]],
+    assert_samples_are_identical,
     run_nuts_mcmc,
     mcmc_default_options: dict[str, Any],
     collection_of_parameter_values: tuple[dict[str, npt.ArrayLike], ...] = (
@@ -96,18 +96,16 @@ def test_model_constructor(
 
         # Confirm that the two models are indeed identical.
         # TODO: Refactor this into a "assert models are equal" method or something.
-        via_model: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+        via_model = run_nuts_mcmc(
             realisation,
             mcmc_kwargs=mcmc_default_options,
-        ).get_samples()
-        via_expected: dict[str, npt.ArrayLike] = run_nuts_mcmc(
+        )
+        via_expected = run_nuts_mcmc(
             expected_realisation,
             mcmc_kwargs=mcmc_default_options,
-        ).get_samples()
+        )
 
-        for sample_name, samples in via_model.items():
-            assert sample_name in via_expected
-            assert np.allclose(samples, via_expected[sample_name])
+        assert_samples_are_identical(via_model, via_expected)
 
 
 def test_model_constructor_missing_parameter(

--- a/tests/test_node/test_create_model_site.py
+++ b/tests/test_node/test_create_model_site.py
@@ -1,41 +1,13 @@
 import re
 from collections.abc import Callable
-from typing import Concatenate, TypeAlias
 
-import jax
 import numpy as np
 import numpy.typing as npt
 import numpyro
 import pytest
 from numpyro.distributions import Normal
-from numpyro.infer import MCMC, NUTS
 
 from causalprog.graph.node import DistributionNode
-
-MCMCRunner: TypeAlias = Callable[Concatenate[Callable, ...], MCMC]
-
-
-@pytest.fixture(scope="session")
-def mcmc_default_options() -> dict[str, float]:
-    return {"num_warmup": 500, "num_samples": 1000}
-
-
-@pytest.fixture
-def run_nuts_mcmc(
-    rng_key: jax.Array,
-) -> MCMCRunner:
-    def inner(model, *, nuts_kwargs=None, mcmc_kwargs=None) -> MCMC:
-        if not nuts_kwargs:
-            nuts_kwargs = {}
-        if not mcmc_kwargs:
-            mcmc_kwargs = {}
-
-        kernel = NUTS(model, **nuts_kwargs)
-        mcmc = MCMC(kernel, **mcmc_kwargs)
-        mcmc.run(rng_key)
-        return mcmc
-
-    return inner
 
 
 @pytest.mark.parametrize(
@@ -105,7 +77,7 @@ def test_create_model_site(
     node: DistributionNode,
     dependent_nodes: Callable[[], dict[str, npt.ArrayLike]],
     identical_model: Exception | Callable[[], npt.ArrayLike],
-    run_nuts_mcmc: MCMCRunner,
+    run_nuts_mcmc,
     mcmc_default_options: dict[str, float],
 ) -> None:
     """Test use and error cases for create_distribution."""

--- a/tests/test_node/test_create_model_site.py
+++ b/tests/test_node/test_create_model_site.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable
 
 import numpy as np
@@ -77,14 +76,13 @@ def test_create_model_site(
     node: DistributionNode,
     dependent_nodes: Callable[[], dict[str, npt.ArrayLike]],
     identical_model: Exception | Callable[[], npt.ArrayLike],
+    raises_context,
     run_nuts_mcmc,
     mcmc_default_options: dict[str, float],
 ) -> None:
     """Test use and error cases for create_distribution."""
     if isinstance(identical_model, Exception):
-        with pytest.raises(
-            type(identical_model), match=re.escape(str(identical_model))
-        ):
+        with raises_context(identical_model):
             node.create_model_site(**dependent_nodes())
     else:
         # TODO: Refactor this into a "assert models are equal" method or something.


### PR DESCRIPTION
Concerns #62 |

Implements the structure for the test suite as set out in #62. The test suite now looks like:

```default
tests/
    fixtures/
    <unit tests, broken down into subfolders>/
    test_integration/
    conftext.py
```

`conftext.py` is setup to automatically discover all fixtures defined inside the `fixtures` directory when the tests are run, which means we can reduce code duplication across the test suite where possible. In particular, this means that the TODOs that were present in #59 have now been addressed.

I haven't updated or moved around anything else in the test suite, so we'll need to go through our other tests to check if they conform to this new structure at some point (again, #62). I also didn't introduce the `test_unit` subfolder, but we can do this if we want to (though it will involve moving a whole bunch of files inside `tests/` to `tests/test_unit`, making the PR noisy).

Also updated the docs build to include this information, and point to a few "useful" fixtures that will likely have widespread use.