### PR TITLE
Cookie notice for GDPR compliance

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,9 @@
 site_name: "causalprog"
 site_description: "Documentation website for causalprog"
 site_author: "Collaborations team, UCL Centre for Advanced Research Computing"
-copyright: "Copyright © 2025 University College London"
+copyright: >
+  Copyright © 2025 University College London -
+  <a href="#__consent">Change cookie settings</a>
 repo_url: "https://github.com/UCL/causalprog/"
 repo_name: "UCL/causalprog"
 edit_uri: edit/main/docs/
@@ -65,6 +67,17 @@ plugins:
       closing_tag: "!}"
 
 extra:
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
+    actions:
+      - reject
+      - manage
+      - accept
   social:
     - icon: fontawesome/brands/github
       link: "https://github.com/UCL"


### PR DESCRIPTION
Just to make sure that we comply with GDPR, since we currently have a blue circle and not a green tick [in the long list of repository websites on the big list](https://github.com/UCL-ARC/github-administration/issues/26#issuecomment-3244286021).

This just adds a super-safe consent banner and a means for people to later change their cookie preferences later, if they need to. Instructions followed to make these changes [are here](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/).