### PR TITLE
Use objects for solver outcomes, not errors and tuples

### DIFF
--- a/src/causalprog/solvers/sgd.py
+++ b/src/causalprog/solvers/sgd.py
@@ -110,7 +110,7 @@ def stochastic_gradient_descent(
     )
 
     return SolverResult(
-        arg_result=current_params,
+        fn_args=current_params,
         grad_val=gradient_value,
         iters=iters_used,
         maxiter=maxiter,

--- a/src/causalprog/solvers/solver_result.py
+++ b/src/causalprog/solvers/solver_result.py
@@ -16,20 +16,20 @@ class SolverResult:
     comes out of running one of the solver methods on a causal problem.
 
     Attributes:
-        arg_result: Argument to the objective function at final iteration (the solution,
+        fn_args: Argument to the objective function at final iteration (the solution,
             if `successful is `True`).
-        grad_val: Value of the gradient of the objective function at the `arg_result`.
+        grad_val: Value of the gradient of the objective function at the `fn_args`.
         iters: Number of iterations performed.
         maxiter: Maximum number of iterations the solver was permitted to perform.
-        obj_val: Value of the objective function at `arg_result`.
+        obj_val: Value of the objective function at `fn_args`.
         reason: Human-readable string explaining success or reasons for solver failure.
-        successful: `True` if solver converged, in which case `arg_result` is the
+        successful: `True` if solver converged, in which case `fn_args` is the
             argument to the objective function at the solution of the problem being
             solved. `False` otherwise.
 
     """
 
-    arg_result: PyTree
+    fn_args: PyTree
     grad_val: PyTree
     iters: int
     maxiter: int

--- a/tests/test_integration/test_two_normal_example.py
+++ b/tests/test_integration/test_two_normal_example.py
@@ -119,7 +119,7 @@ def test_two_normal_example(
     assert result.successful, "SGD did not converge."
 
     # Unpack concatenated arguments
-    params, l_mult = result.arg_result
+    params, l_mult = result.fn_args
 
     # The lagrangian is independent of nu_x, thus it should not have changed value.
     assert jnp.isclose(params["cov2"], nu_x_starting_value), (

--- a/tests/test_solvers/test_sgd.py
+++ b/tests/test_solvers/test_sgd.py
@@ -85,5 +85,5 @@ def test_sgd(
         assert result.reason == expected
     else:
         assert jax.tree_util.tree_all(
-            jax.tree_util.tree_map(jax.numpy.allclose, result.arg_result, expected)
+            jax.tree_util.tree_map(jax.numpy.allclose, result.fn_args, expected)
         )


### PR DESCRIPTION
TLDR;

- Creates a `SolverResult` class that can be used as the output for any methods we implement to solve casual problems.
- Replaces the return type of the SGD solver method with this class, populating appropriate values.

## Why?

A couple of reasons.

The first is that the SGD method was already returning a tuple of 4 values, the order of which was both somewhat arbitrary and going to be a pain to enforce consistently across the codebase if we ever add any more solver methods. Having a simple container object that can store this information for later access is cleaner to return.

The second being that we don't want to rely on throwing errors when one of our solver methods fails to converge (or encounters some other problem), since we may want to take action based on this result. (This is particularly relevant to the Quadratic Penalty Method). Instead, we should just bundle all the relevant information into the object that's returned, which can indicate whether or not the solver method was successful on inspection of an attribute.