### PR TITLE
`QuadratureMethod` can now integrate things

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional-dependencies = {dev = [
     "numpy",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
 ]}
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/causalprog/quadrature/base.py
+++ b/src/causalprog/quadrature/base.py
@@ -50,6 +50,10 @@ class QuadratureMethod(ABC):
         Integrate the `integrand` over `[a,b]` using the `QuadratureMethod`.
 
         Subclasses should implement specific details.
+
+        Ideally, we would be able to assume that the integrand is vectorised
+        in it's first argument (Callable[[ArrayLike, ...], ArrayLike]).
+        Then we could do without the for-loop in each of the subclass implementations.
         """
 
     @abstractmethod

--- a/src/causalprog/quadrature/base.py
+++ b/src/causalprog/quadrature/base.py
@@ -53,13 +53,9 @@ class QuadratureMethod(ABC):
         """
 
     @abstractmethod
-    def points_and_weights(
-        self, a: float = -1.0, b: float = 1.0
-    ) -> tuple[npt.NDArray, npt.NDArray]:
-        """Get quadrature points and weights for performing integration on $[a,b]$."""
+    def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
+        """Get the quadrature points and weights."""
 
-    def pts_wts_tuples(
-        self, a: float = -1.0, b: float = 1.0
-    ) -> list[tuple[float, float]]:
+    def pts_wts_tuples(self) -> list[tuple[float, float]]:
         """Get `(point, weight)` pairs as a list of tuples."""
-        return list(zip(*self.points_and_weights(a=a, b=b), strict=True))
+        return list(zip(*self.points_and_weights(), strict=True))

--- a/src/causalprog/quadrature/base.py
+++ b/src/causalprog/quadrature/base.py
@@ -1,8 +1,13 @@
 """Base quadrature class."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Concatenate, ParamSpec, TypeAlias
 
 import numpy.typing as npt
+
+IntegrandArgs = ParamSpec("IntegrandArgs")
+Integrand: TypeAlias = Callable[Concatenate[float, IntegrandArgs], float]
 
 
 class QuadratureMethod(ABC):
@@ -24,5 +29,24 @@ class QuadratureMethod(ABC):
         return self._npts
 
     @abstractmethod
+    def integrate(
+        self,
+        integrand: Integrand,
+        a: float = -1.0,
+        b: float = 1.0,
+        *integrand_args: IntegrandArgs.args,
+        **integrand_kwargs: IntegrandArgs.kwargs,
+    ) -> float:
+        """
+        Integrate the `integrand` over `[a,b]` using the `QuadratureMethod`.
+
+        Subclasses should implement specific details.
+        """
+
+    @abstractmethod
     def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
         """Get the quadrature points and weights."""
+
+    def pts_wts_tuples(self) -> list[tuple[float, float]]:
+        """Get `(point, weight)` pairs as a list of tuples."""
+        return list(zip(*self.points_and_weights(), strict=True))

--- a/src/causalprog/quadrature/base.py
+++ b/src/causalprog/quadrature/base.py
@@ -53,9 +53,13 @@ class QuadratureMethod(ABC):
         """
 
     @abstractmethod
-    def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
-        """Get the quadrature points and weights."""
+    def points_and_weights(
+        self, a: float = -1.0, b: float = 1.0
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        """Get quadrature points and weights for performing integration on $[a,b]$."""
 
-    def pts_wts_tuples(self) -> list[tuple[float, float]]:
+    def pts_wts_tuples(
+        self, a: float = -1.0, b: float = 1.0
+    ) -> list[tuple[float, float]]:
         """Get `(point, weight)` pairs as a list of tuples."""
-        return list(zip(*self.points_and_weights(), strict=True))
+        return list(zip(*self.points_and_weights(a=a, b=b), strict=True))

--- a/src/causalprog/quadrature/base.py
+++ b/src/causalprog/quadrature/base.py
@@ -11,7 +11,16 @@ Integrand: TypeAlias = Callable[Concatenate[float, IntegrandArgs], float]
 
 
 class QuadratureMethod(ABC):
-    """An abstract quadrature method."""
+    """
+    An abstract quadrature method.
+
+    All `QuadratureMethod`s are required to provide a means of obtaining the
+    points and weights that they use, accessible through the `points_and_weights`
+    method of an instance.
+
+    Instances also provide an `integrate` method, to perform
+    numerical integration of an integrand.
+    """
 
     def __init__(self, npoints: int) -> None:
         """

--- a/src/causalprog/quadrature/gaussian.py
+++ b/src/causalprog/quadrature/gaussian.py
@@ -47,7 +47,7 @@ class GaussianQuadrature(QuadratureMethod):
         *integrand_args: IntegrandArgs.args,
         **integrand_kwargs: IntegrandArgs.kwargs,
     ) -> float:
-        """Integrate the `integrand` over `[a,b]` via Gaussian quadrature."""
+        """Integrate the `integrand` over $[a,b]$ via Gaussian quadrature."""
         change_of_vars_derivative = (b - a) / 2
         interval_midpoint = (b + a) / 2
 

--- a/src/causalprog/quadrature/gaussian.py
+++ b/src/causalprog/quadrature/gaussian.py
@@ -3,11 +3,24 @@
 import numpy.typing as npt
 import quadraturerules
 
-from .base import QuadratureMethod
+from .base import Integrand, IntegrandArgs, QuadratureMethod
 
 
 class GaussianQuadrature(QuadratureMethod):
-    """A Gaussian quadrature rule."""
+    r"""
+    A Gaussian quadrature rule.
+
+    The domain of integration for the points $p_i$ and weights $w_i$ is $[-1,1]$.
+    This means that to integrate an integrand $f$ over the interval $[a,b]$, the
+    approximation
+
+    $$
+    \int_a^b f(x) dx \approx
+    \frac{b - a}{2}\sum_{w_i}f\left \frac{b - a}{2} p_i + \frac{b + a}{2}\right)
+    $$
+
+    is used.
+    """
 
     def __init__(self, npoints: int) -> None:
         """
@@ -24,7 +37,32 @@ class GaussianQuadrature(QuadratureMethod):
             npoints,
         )
         self._pts = pts[:, 1] - pts[:, 0]
-        self._wts = wts
+        self._wts = wts * 2.0
+
+    def integrate(
+        self,
+        integrand: Integrand,
+        a: float = -1,
+        b: float = 1,
+        *integrand_args: IntegrandArgs.args,
+        **integrand_kwargs: IntegrandArgs.kwargs,
+    ) -> float:
+        """Integrate the `integrand` over `[a,b]` via Gaussian quadrature."""
+        change_of_vars_derivative = (b - a) / 2
+        interval_midpoint = (b + a) / 2
+
+        # Ideally, we would be able to assume that the integrand is vectorised
+        # in it's first argument (Callable[[ArrayLike, ...], ArrayLike]).
+        # Then we could do without the for loop here.
+        result = 0.0
+        for p_i, w_i in self.pts_wts_tuples():
+            result += w_i * integrand(
+                change_of_vars_derivative * p_i + interval_midpoint,
+                *integrand_args,
+                **integrand_kwargs,
+            )
+
+        return result * change_of_vars_derivative
 
     def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
         """Get the quadrature points and weights."""

--- a/src/causalprog/quadrature/gaussian.py
+++ b/src/causalprog/quadrature/gaussian.py
@@ -22,6 +22,9 @@ class GaussianQuadrature(QuadratureMethod):
     is used.
     """
 
+    _pts: npt.NDArray
+    _wts: npt.NDArray
+
     def __init__(self, npoints: int) -> None:
         """
         Initialise.
@@ -48,22 +51,23 @@ class GaussianQuadrature(QuadratureMethod):
         **integrand_kwargs: IntegrandArgs.kwargs,
     ) -> float:
         """Integrate the `integrand` over $[a,b]$ via Gaussian quadrature."""
-        change_of_vars_derivative = (b - a) / 2
-        interval_midpoint = (b + a) / 2
-
         # Ideally, we would be able to assume that the integrand is vectorised
         # in it's first argument (Callable[[ArrayLike, ...], ArrayLike]).
         # Then we could do without the for loop here.
         result = 0.0
-        for p_i, w_i in self.pts_wts_tuples():
+        for p_i, w_i in self.pts_wts_tuples(a=a, b=b):
             result += w_i * integrand(
-                change_of_vars_derivative * p_i + interval_midpoint,
+                p_i,
                 *integrand_args,
                 **integrand_kwargs,
             )
 
-        return result * change_of_vars_derivative
+        return result * (b - a) / 2
 
-    def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
-        """Get the quadrature points and weights."""
-        return self._pts, self._wts
+    def points_and_weights(
+        self, a: float = -1.0, b: float = 1.0
+    ) -> tuple[npt.NDArray, npt.NDArray]:
+        """Get quadrature points and weights for performing integration on $[a,b]$."""
+        change_of_vars_derivative = (b - a) / 2.0
+        interval_midpoint = (b + a) / 2.0
+        return self._pts * change_of_vars_derivative + interval_midpoint, self._wts

--- a/src/causalprog/quadrature/gaussian.py
+++ b/src/causalprog/quadrature/gaussian.py
@@ -51,9 +51,6 @@ class GaussianQuadrature(QuadratureMethod):
         **integrand_kwargs: IntegrandArgs.kwargs,
     ) -> float:
         """Integrate the `integrand` over $[a,b]$ via Gaussian quadrature."""
-        # Ideally, we would be able to assume that the integrand is vectorised
-        # in it's first argument (Callable[[ArrayLike, ...], ArrayLike]).
-        # Then we could do without the for loop here.
         result = 0.0
         for p_i, w_i in self.pts_wts_tuples(a=a, b=b):
             result += w_i * integrand(

--- a/src/causalprog/quadrature/gaussian.py
+++ b/src/causalprog/quadrature/gaussian.py
@@ -22,9 +22,6 @@ class GaussianQuadrature(QuadratureMethod):
     is used.
     """
 
-    _pts: npt.NDArray
-    _wts: npt.NDArray
-
     def __init__(self, npoints: int) -> None:
         """
         Initialise.
@@ -51,23 +48,22 @@ class GaussianQuadrature(QuadratureMethod):
         **integrand_kwargs: IntegrandArgs.kwargs,
     ) -> float:
         """Integrate the `integrand` over $[a,b]$ via Gaussian quadrature."""
+        change_of_vars_derivative = (b - a) / 2
+        interval_midpoint = (b + a) / 2
+
         # Ideally, we would be able to assume that the integrand is vectorised
         # in it's first argument (Callable[[ArrayLike, ...], ArrayLike]).
         # Then we could do without the for loop here.
         result = 0.0
-        for p_i, w_i in self.pts_wts_tuples(a=a, b=b):
+        for p_i, w_i in self.pts_wts_tuples():
             result += w_i * integrand(
-                p_i,
+                change_of_vars_derivative * p_i + interval_midpoint,
                 *integrand_args,
                 **integrand_kwargs,
             )
 
-        return result * (b - a) / 2
+        return result * change_of_vars_derivative
 
-    def points_and_weights(
-        self, a: float = -1.0, b: float = 1.0
-    ) -> tuple[npt.NDArray, npt.NDArray]:
-        """Get quadrature points and weights for performing integration on $[a,b]$."""
-        change_of_vars_derivative = (b - a) / 2.0
-        interval_midpoint = (b + a) / 2.0
-        return self._pts * change_of_vars_derivative + interval_midpoint, self._wts
+    def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
+        """Get the quadrature points and weights."""
+        return self._pts, self._wts

--- a/src/causalprog/quadrature/monte_carlo.py
+++ b/src/causalprog/quadrature/monte_carlo.py
@@ -50,17 +50,20 @@ class MonteCarloGaussianQuadrature(QuadratureMethod):
 
         FIXME: This means that we are not guaranteed to use `self.npoints` samples
         on definite integrals! Since we are sampling from a standard Gaussian, we'll
-        have to filter some samples we draw
+        have to filter some samples we draw. Hence the valid_samples stuff. Would be
+        better if we could reliably generate appropriate samples in the interval.
         """
         result = 0.0
-        valid_samples = 0
 
-        for p_i, w_i in self.pts_wts_tuples():
-            if a <= p_i <= b:
-                result += w_i * integrand(p_i, *integrand_args, **integrand_kwargs)
-                valid_samples += 1
+        pts = jax.random.truncated_normal(
+            self.rng_key, lower=a, upper=b, shape=(self.npoints,)
+        )
+        wts = jax.scipy.stats.truncnorm.pdf(pts, a, b)
 
-        return result / valid_samples
+        for p_i, w_i in zip(pts, wts, strict=True):
+            result += integrand(p_i, *integrand_args, **integrand_kwargs) / w_i
+
+        return result / self.npoints
 
     def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
         """Get the quadrature points and weights."""

--- a/src/causalprog/quadrature/monte_carlo.py
+++ b/src/causalprog/quadrature/monte_carlo.py
@@ -1,7 +1,6 @@
 """Monte Carlo quadrature."""
 
 import jax
-import numpy as np
 import numpy.typing as npt
 
 from .base import Integrand, IntegrandArgs, QuadratureMethod
@@ -12,14 +11,14 @@ class MonteCarloGaussianQuadrature(QuadratureMethod):
     Monte Carlo quadrature, sampled from a standard Gaussian.
 
     Let $N$ be the number of sample points to be used by the scheme.
-    The quadrature method then draws $N$ sample points $p_i$ from the standard
-    Gaussian, and approximates integrals as
+    The quadrature method approximates the integral
 
     $$
-    \int_a^b f(x) dx =
-    \int_{-\inf}^{\inf} \mathbb{1}_{[a,b]} f(x) dx \approx
-    \frac{1}{N}\sum_{p_i} f(p_i).
+    \int_a^b f(x) dx
+    \approx \frac{1}{N}\sum_{p_i} \frac{f(p_i)}{\mathcal{P}(p_i)},
     $$
+
+    where $p_i\in[a,b]$ are $N$ samples drawn from a standard Gaussian.
     """
 
     def __init__(self, npoints: int, *, rng_key: jax.Array) -> None:
@@ -41,32 +40,20 @@ class MonteCarloGaussianQuadrature(QuadratureMethod):
         *integrand_args: IntegrandArgs.args,
         **integrand_kwargs: IntegrandArgs.kwargs,
     ) -> float:
-        """
-        Perform Monte-Carlo integration, sampling from a standard Gaussian.
-
-        By default, the domain of integration is the real line. Integrals over
-        smaller domains are approximated by multiplying the integrand by the
-        indicator function.
-
-        FIXME: This means that we are not guaranteed to use `self.npoints` samples
-        on definite integrals! Since we are sampling from a standard Gaussian, we'll
-        have to filter some samples we draw. Hence the valid_samples stuff. Would be
-        better if we could reliably generate appropriate samples in the interval.
-        """
+        """Perform Monte-Carlo integration of the `integrand` over $[a,b]$."""
         result = 0.0
 
-        pts = jax.random.truncated_normal(
-            self.rng_key, lower=a, upper=b, shape=(self.npoints,)
-        )
-        wts = jax.scipy.stats.truncnorm.pdf(pts, a, b)
-
-        for p_i, w_i in zip(pts, wts, strict=True):
+        for p_i, w_i in self.pts_wts_tuples(a=a, b=b):
             result += integrand(p_i, *integrand_args, **integrand_kwargs) / w_i
 
         return result / self.npoints
 
-    def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
+    def points_and_weights(
+        self, a: float = -1.0, b: float = 1.0
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         """Get the quadrature points and weights."""
-        return jax.random.normal(self.rng_key, (self.npoints,)), np.ones(
-            self.npoints
-        ) / self.npoints
+        pts = jax.random.truncated_normal(
+            self.rng_key, lower=a, upper=b, shape=(self.npoints,)
+        )
+        wts = jax.scipy.stats.truncnorm.pdf(pts, a, b)
+        return pts, wts

--- a/src/causalprog/quadrature/monte_carlo.py
+++ b/src/causalprog/quadrature/monte_carlo.py
@@ -4,11 +4,23 @@ import jax
 import numpy as np
 import numpy.typing as npt
 
-from .base import QuadratureMethod
+from .base import Integrand, IntegrandArgs, QuadratureMethod
 
 
 class MonteCarloGaussianQuadrature(QuadratureMethod):
-    """Monte Carlo quadrature sampled from standard Gaussian."""
+    r"""
+    Monte Carlo quadrature, sampled from a standard Gaussian.
+
+    Let $N$ be the number of sample points to be used by the scheme.
+    The quadrature method then draws $N$ sample points $p_i$ from the standard
+    Gaussian, and approximates integrals as
+
+    $$
+    \int_a^b f(x) dx =
+    \int_{-\inf}^{\inf} \mathbb{1}_{[a,b]} f(x) dx \approx
+    \frac{1}{N}\sum_{p_i} f(p_i).
+    $$
+    """
 
     def __init__(self, npoints: int, *, rng_key: jax.Array) -> None:
         """
@@ -20,6 +32,35 @@ class MonteCarloGaussianQuadrature(QuadratureMethod):
         """
         super().__init__(npoints)
         self.rng_key = rng_key
+
+    def integrate(
+        self,
+        integrand: Integrand,
+        a: float = -1.0,
+        b: float = 1.0,
+        *integrand_args: IntegrandArgs.args,
+        **integrand_kwargs: IntegrandArgs.kwargs,
+    ) -> float:
+        """
+        Perform Monte-Carlo integration, sampling from a standard Gaussian.
+
+        By default, the domain of integration is the real line. Integrals over
+        smaller domains are approximated by multiplying the integrand by the
+        indicator function.
+
+        FIXME: This means that we are not guaranteed to use `self.npoints` samples
+        on definite integrals! Since we are sampling from a standard Gaussian, we'll
+        have to filter some samples we draw
+        """
+        result = 0.0
+        valid_samples = 0
+
+        for p_i, w_i in self.pts_wts_tuples():
+            if a <= p_i <= b:
+                result += w_i * integrand(p_i, *integrand_args, **integrand_kwargs)
+                valid_samples += 1
+
+        return result / valid_samples
 
     def points_and_weights(self) -> tuple[npt.NDArray, npt.NDArray]:
         """Get the quadrature points and weights."""

--- a/tests/test_quadrature/test_gaussian_quadrature.py
+++ b/tests/test_quadrature/test_gaussian_quadrature.py
@@ -1,17 +1,52 @@
+import jax
 import jax.numpy as jnp
+import pytest
 
 from causalprog.quadrature import GaussianQuadrature
 
 
+@pytest.mark.parametrize(
+    ("coeffs", "interval", "exact_integral"),
+    [
+        pytest.param(
+            jnp.array([1.0]),
+            (-1, 1),
+            2.0,
+            id="[-1, 1] f(x) = 1",
+        ),
+        pytest.param(
+            jnp.array([0.0, 1.0]),
+            (-1, 1),
+            0.0,
+            id="[-1, 1] f(x) = x",
+        ),
+        pytest.param(
+            jnp.array([1.0, -2.0, 1.0]),
+            (-1, 1),
+            8.0 / 3.0,
+            id="[-1, 1] f(x) = x^2 - 2x + 1",
+        ),
+        pytest.param(
+            jnp.array([0.0, 1.0]),
+            (0, 5),
+            5.0 * 5.0 / 2.0,
+            id="[0, 5] f(x) = x",
+        ),
+        pytest.param(
+            jnp.array([0.0, 1.0]),
+            (-5, 0),
+            -5.0 * 5.0 / 2.0,
+            id="[-5, 0] f(x) = x",
+        ),
+    ],
+)
 def test_gaussian_quadrature_polynomials(
-    coeffs: jnp.Array, interval: tuple[float, float], exact_integral: float
+    coeffs: jax.Array, interval: tuple[float, float], exact_integral: float
 ) -> None:
-    degree = coeffs.size - 1
-
-    def _integrand(x: float, c: jnp.Array):
+    def _integrand(x: float, c: jax.Array):
         return (c * x ** jnp.arange(c.size)).sum()
 
-    computed_integral = GaussianQuadrature(degree).integrate(
+    computed_integral = GaussianQuadrature(coeffs.size).integrate(
         _integrand, a=interval[0], b=interval[1], c=coeffs
     )
 

--- a/tests/test_quadrature/test_gaussian_quadrature.py
+++ b/tests/test_quadrature/test_gaussian_quadrature.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import pytest
+import pytest_mock
 
 from causalprog.quadrature import GaussianQuadrature
 
@@ -53,3 +54,46 @@ def test_gaussian_quadrature_polynomials(
     )
 
     assert jnp.isclose(exact_integral, computed_integral)
+
+
+def test_gaussian_integration_formula(
+    mocker: pytest_mock.MockerFixture,
+    n_points: int = 10,
+    a: float = -1.0,
+    b: float = 1.0,
+) -> None:
+    """
+    Assert that, given sample point values and weights for these points, the
+    approximation to the integral is correctly computed.
+
+    Note that we deliberately mock the generation of the sample points and weights
+    in this function, to determine if the correct formula is being applied. The actual
+    result that will be computed by the integration process in this test is nonsensical,
+    because we are deliberately using a fixed set of custom values for the points &
+    weights that have not come from a distribution.
+    """
+
+    def _integrand(x):
+        return x**2 - 2.0 * x + 1.0
+
+    def _fixed_pts_and_weights(_a=-1.0, _b=1.0, *args, **kwargs):
+        return jnp.linspace(_a, _b, num=n_points, endpoint=True), 0.5 * jnp.ones(
+            (n_points,)
+        )
+
+    q = GaussianQuadrature(n_points)
+    mocker.patch.object(
+        q,
+        "points_and_weights",
+        new=_fixed_pts_and_weights,
+    )
+    expected_pts_to_use, expected_wts_to_use = q.points_and_weights(a=a, b=b)
+
+    computed_integral = q.integrate(_integrand, a=a, b=b)
+
+    expected_integral = 0.0
+    for p, w in zip(expected_pts_to_use, expected_wts_to_use, strict=True):
+        expected_integral += _integrand(p) * w
+    expected_integral *= (b - a) / 2
+
+    assert jnp.isclose(computed_integral, expected_integral)

--- a/tests/test_quadrature/test_gaussian_quadrature.py
+++ b/tests/test_quadrature/test_gaussian_quadrature.py
@@ -43,6 +43,8 @@ from causalprog.quadrature import GaussianQuadrature
 def test_gaussian_quadrature_polynomials(
     coeffs: jax.Array, interval: tuple[float, float], exact_integral: float
 ) -> None:
+    """Gaussian quadrature with n points is exact for polynomials with degree < n."""
+
     def _integrand(x: float, c: jax.Array):
         return (c * x ** jnp.arange(c.size)).sum()
 

--- a/tests/test_quadrature/test_gaussian_quadrature.py
+++ b/tests/test_quadrature/test_gaussian_quadrature.py
@@ -58,19 +58,19 @@ def test_gaussian_quadrature_polynomials(
 
 def test_gaussian_integration_formula(
     mocker: pytest_mock.MockerFixture,
-    n_points: int = 10,
+    n_points: int = 100,
     a: float = -1.0,
     b: float = 1.0,
 ) -> None:
     """
-    Assert that, given sample point values and weights for these points, the
+    Assert that, once the point values and weights for these points are determined, the
     approximation to the integral is correctly computed.
 
     Note that we deliberately mock the generation of the sample points and weights
     in this function, to determine if the correct formula is being applied. The actual
     result that will be computed by the integration process in this test is nonsensical,
     because we are deliberately using a fixed set of custom values for the points &
-    weights that have not come from a distribution.
+    weights that have not come from a the Legendre polynomials.
     """
 
     def _integrand(x):
@@ -81,7 +81,9 @@ def test_gaussian_integration_formula(
             (n_points,)
         )
 
-    q = GaussianQuadrature(n_points)
+    # Note that the degree argument here is irrelevant, as we will overwrite the
+    # generation of points.
+    q = GaussianQuadrature(1)
     mocker.patch.object(
         q,
         "points_and_weights",

--- a/tests/test_quadrature/test_gaussian_quadrature.py
+++ b/tests/test_quadrature/test_gaussian_quadrature.py
@@ -1,16 +1,18 @@
-import numpy as np
-import pytest
+import jax.numpy as jnp
 
-import causalprog
+from causalprog.quadrature import GaussianQuadrature
 
 
-@pytest.mark.parametrize("degree", range(1, 7))
-def test_gaussian_quadrature(degree):
-    q = causalprog.quadrature.GaussianQuadrature(degree)
+def test_gaussian_quadrature_polynomials(
+    coeffs: jnp.Array, interval: tuple[float, float], exact_integral: float
+) -> None:
+    degree = coeffs.size - 1
 
-    pts, wts = q.points_and_weights()
+    def _integrand(x: float, c: jnp.Array):
+        return (c * x ** jnp.arange(c.size)).sum()
 
-    for i in range(degree + 1):
-        integral = sum(2 * wts * pts**i)
-        exact_integral = 2 / (i + 1) if i % 2 == 0 else 0
-        assert np.isclose(integral, exact_integral)
+    computed_integral = GaussianQuadrature(degree).integrate(
+        _integrand, a=interval[0], b=interval[1], c=coeffs
+    )
+
+    assert jnp.isclose(exact_integral, computed_integral)

--- a/tests/test_quadrature/test_monte_carlo.py
+++ b/tests/test_quadrature/test_monte_carlo.py
@@ -69,7 +69,7 @@ def test_monte_carlo_integration_gaussians(
     _assert_within_mc_error(computed_integral, expected_integral, n_points)
 
 
-def test_monte_carlo_formula_application(
+def test_monte_carlo_integration_formula(
     mocker: pytest_mock.MockerFixture,
     rng_key,
     n_points: int = 100,
@@ -91,7 +91,9 @@ def test_monte_carlo_formula_application(
         return x**2 - 2.0 * x + 1.0
 
     def _fixed_pts_and_weights(_a=-1.0, _b=1.0, *args, **kwargs):
-        return jnp.linspace(_a, _b, num=n_points, endpoint=True), jnp.ones((n_points,))
+        return jnp.linspace(_a, _b, num=n_points, endpoint=True), 0.5 * jnp.ones(
+            (n_points,)
+        )
 
     q = MonteCarloGaussianQuadrature(n_points, rng_key=rng_key)
     mocker.patch.object(

--- a/tests/test_quadrature/test_monte_carlo.py
+++ b/tests/test_quadrature/test_monte_carlo.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import causalprog
+from causalprog.quadrature import MonteCarloGaussianQuadrature
 
 
 @pytest.mark.parametrize("degree", [500, 1000])
@@ -12,3 +13,25 @@ def test_monte_carlo_quadrature(degree, rng_key):
 
     assert np.isclose(sum(wts), 1.0)
     assert np.isclose(sum(wts * pts), 0.0, atol=1e-2)
+
+
+def test_monte_carlo_integration(
+    rng_key,
+    npoints=20_000,
+) -> None:
+    q = MonteCarloGaussianQuadrature(npoints, rng_key=rng_key)
+
+    def _integrand(x):
+        # return np.exp(-(x**2))
+        return x
+
+    a = -float("inf")
+    b = float("inf")
+
+    a = 0.0
+    b = 1.0
+
+    computed_integral = q.integrate(_integrand, a=a, b=b)
+    sqrt_pi = np.sqrt(np.pi)
+
+    print(computed_integral - sqrt_pi)

--- a/tests/test_quadrature/test_monte_carlo.py
+++ b/tests/test_quadrature/test_monte_carlo.py
@@ -1,37 +1,111 @@
-import numpy as np
+import jax.numpy as jnp
 import pytest
+import pytest_mock
 
-import causalprog
 from causalprog.quadrature import MonteCarloGaussianQuadrature
 
-
-@pytest.mark.parametrize("degree", [500, 1000])
-def test_monte_carlo_quadrature(degree, rng_key):
-    q = causalprog.quadrature.MonteCarloGaussianQuadrature(degree, rng_key=rng_key)
-
-    pts, wts = q.points_and_weights()
-
-    assert np.isclose(sum(wts), 1.0)
-    assert np.isclose(sum(wts * pts), 0.0, atol=1e-2)
+INF = float("inf")
 
 
-def test_monte_carlo_integration(
-    rng_key,
-    npoints=20_000,
+def _assert_within_mc_error(
+    x: float, y: float, n_samples: int, forgiveness_factor: float = 1.25
 ) -> None:
-    q = MonteCarloGaussianQuadrature(npoints, rng_key=rng_key)
+    """
+    Shortcut function for testing computed values of MC integrals.
+
+    MC integrals are inherently stochastic, but in general we expect that the
+    absolute error (of the computed integral from the true value) decreases
+    as roughly the square-root of the number of samples. The `forgiveness_factor`
+    is essentially a quick-hack to get around the fact that the shape of the
+    integrand also affects the quality of the approximation, and to provide us with
+    some wiggle-room.
+    """
+    assert jnp.abs(x - y) <= forgiveness_factor / jnp.sqrt(n_samples)
+
+
+def _gaussian_shape(x: float) -> float:
+    return jnp.exp(-(x**2))
+
+
+@pytest.mark.parametrize("n_points", [100, 1000, 10_000])
+def test_monte_carlo_integration_constant(
+    n_points: int,
+    rng_key,
+    constant_value: float = 2.0,
+    interval: tuple[float, float] = (0.0, 1.0),
+) -> None:
+    """Check that the constant function is (suitably correctly) integrated."""
+    expected_integral = (interval[1] - interval[0]) * constant_value
+
+    q = MonteCarloGaussianQuadrature(n_points, rng_key=rng_key)
+    computed_integral = q.integrate(
+        lambda _: constant_value, a=interval[0], b=interval[1]
+    )
+
+    _assert_within_mc_error(computed_integral, expected_integral, n_points)
+
+
+@pytest.mark.parametrize("n_points", [100, 1000, 10_000, 100_000])
+@pytest.mark.parametrize("half_interval", [True, False])
+def test_monte_carlo_integration_gaussians(
+    n_points: int,
+    rng_key,
+    *,
+    half_interval: bool,
+    expected_integral: float = jnp.sqrt(jnp.pi),
+) -> None:
+    """Test the performance of Monte-Carlo integration on a Gaussian-shaped integrand,
+    along the entire real line and positive half-line.
+    """
+    interval = [-INF, INF]
+    expected_integral = jnp.sqrt(jnp.pi)
+    if half_interval:
+        interval[0] = 0.0
+        expected_integral /= 2.0
+
+    q = MonteCarloGaussianQuadrature(n_points, rng_key=rng_key)
+    computed_integral = q.integrate(_gaussian_shape, a=interval[0], b=interval[1])
+
+    _assert_within_mc_error(computed_integral, expected_integral, n_points)
+
+
+def test_monte_carlo_formula_application(
+    mocker: pytest_mock.MockerFixture,
+    rng_key,
+    n_points: int = 100,
+    a: float = -1.0,
+    b: float = 1.0,
+) -> None:
+    """
+    Assert that, given sample point values and weights for these points, the Monte
+    Carlo integral is correctly computed.
+
+    Note that we deliberately mock the generation of the sample points and weights
+    in this function, to determine if the correct formula is being applied. The actual
+    result that will be computed by the integration process in this test is nonsensical,
+    because we are deliberately using a fixed set of custom values for the points &
+    weights that have not come from a distribution.
+    """
 
     def _integrand(x):
-        # return np.exp(-(x**2))
-        return x
+        return x**2 - 2.0 * x + 1.0
 
-    a = -float("inf")
-    b = float("inf")
+    def _fixed_pts_and_weights(_a=-1.0, _b=1.0, *args, **kwargs):
+        return jnp.linspace(_a, _b, num=n_points, endpoint=True), jnp.ones((n_points,))
 
-    a = 0.0
-    b = 1.0
+    q = MonteCarloGaussianQuadrature(n_points, rng_key=rng_key)
+    mocker.patch.object(
+        q,
+        "points_and_weights",
+        new=_fixed_pts_and_weights,
+    )
+    expected_pts_to_use, expected_wts_to_use = q.points_and_weights(a=a, b=b)
 
     computed_integral = q.integrate(_integrand, a=a, b=b)
-    sqrt_pi = np.sqrt(np.pi)
 
-    print(computed_integral - sqrt_pi)
+    expected_integral = 0.0
+    for p, w in zip(expected_pts_to_use, expected_wts_to_use, strict=True):
+        expected_integral += _integrand(p) / w
+    expected_integral /= n_points
+
+    assert jnp.isclose(computed_integral, expected_integral)

--- a/tests/test_quadrature/test_monte_carlo.py
+++ b/tests/test_quadrature/test_monte_carlo.py
@@ -4,8 +4,6 @@ import pytest_mock
 
 from causalprog.quadrature import MonteCarloGaussianQuadrature
 
-INF = float("inf")
-
 
 def _assert_within_mc_error(
     x: float, y: float, n_samples: int, forgiveness_factor: float = 1.25
@@ -57,7 +55,7 @@ def test_monte_carlo_integration_gaussians(
     """Test the performance of Monte-Carlo integration on a Gaussian-shaped integrand,
     along the entire real line and positive half-line.
     """
-    interval = [-INF, INF]
+    interval = [-float("inf"), float("inf")]
     expected_integral = jnp.sqrt(jnp.pi)
     if half_interval:
         interval[0] = 0.0


### PR DESCRIPTION
Concerns #129 |

Adds the `integrate` method to the `QuadratureMethod` class, which enables us to actually perform numerical integration with these classes. This means we can put the instructions for performing integrals into each of the `QuadratureMethod` (sub)classes, and not have to worry about manually implementing them within the functions that need to evaluate sch integrals. For example in the $r$-function that we want to build, we can just call `QuadratureMethod.integrate()` instead of manually taking an additional argument that specifies how numerical integration should be performed, and then writing it out in the function itself.

## Changes / Additions

- `QuadratureMethod.integrate` abstract method.
  - Implementations of this method on the `GaussianQuadrature` and `MonteCarloGaussianQuadrature` classes.
- `QuadratureMethod.pts_wts_tuples` which is just a convenience wrapper around the existing `points_and_weights` method, that returns tuples of points and their weights, rather than 2 separate arrays.
- `QuadratureMethod.points_and_weights` now takes arguments `a` and `b` that specify the interval over which quadrature / integration is going to take place.
  - This also means that the returned values are the points and weights to be used in the domain of integration, rather than in the fixed interval $[-1,1]$ in which the quadrature rule is typically defined.
- Tests for the concrete `QuadratureMethod` classes have been overhauled.
  - Both subclasses have a mock-based test that checks the correct formula is being applied _assuming_ the points and weights that are generated by the object are correct.
  - `GaussianQuadrature` is checked for exactness against polynomials of suitable degree.
  - `MonteCarlo...` is checked for near-correctness against constant functions and functions with a Gaussian shape. Indefinite integrals are also considered in these tests. Due to the stochastic nature of the approximation to the integral, several test cases are run, increasing the number of sample points _and_ reducing the expected error accordingly.