### PR TITLE
`learn_initialiser` needs to return the function `B`

### DIFF
--- a/src/causalprog/graph/ricardo.py
+++ b/src/causalprog/graph/ricardo.py
@@ -250,10 +250,16 @@ def build_learn_initialiser(
     It is only necessary to specify arrays that are not mapping over their `0`th axes in
     `evaluation_points_axes_mapping`.
 
+    To avoid broadcasting issues, the number of evaluation points is deduced from the
+    `r_hat_i.size`. For this reason, `r_hat_i` must always be passed as a 1D array of as
+    many elements as there are evaluation points.
+
     Args:
-        r: Regression function, $r$. Typically the output of `build_regression_function`
-        evaluation_points: Set of evaluation points, $\mathcal{D}$
-        r_hat_i: The values of the estimate of r at the evaluation points, $\hat{r}_i$
+        r: Regression function, $r$. Typically the output of
+            `build_regression_function`.
+        evaluation_points: Set of evaluation points, $\mathcal{D}$.
+        r_hat_i: The values of the estimate of r at the evaluation points, $\hat{r}_i$.
+            Must be a 1D array of as many elements as the number of evaluation points.
         evaluation_points_axes_mapping: Axes to vectorise over when evaluating $r$
             at the `evaluation_points`.
 
@@ -268,7 +274,7 @@ def build_learn_initialiser(
         None,
     )
     vectorised_r = jax.vmap(r, in_axes=in_axes)
-    n_eval = r_hat_i.shape[0]
+    n_eval = r_hat_i.size
 
     def _objective_function(theta: ModelParam) -> jax.Array:
         r"""Evaluate $B(\theta)$."""

--- a/src/causalprog/graph/ricardo.py
+++ b/src/causalprog/graph/ricardo.py
@@ -1,7 +1,7 @@
 """Functions to create example graphs."""
 
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 import jax
 from jax.nn import sigmoid, softmax, tanh
@@ -10,8 +10,6 @@ from numpy.typing import NDArray
 
 from causalprog.quadrature import UniformWeightMonteCarloGaussianQuadrature as UWMCGQuad
 from causalprog.quadrature.base import QuadratureMethod
-from causalprog.solvers.sgd import stochastic_gradient_descent
-from causalprog.solvers.solver_result import SolverResult
 
 from .graph import Graph
 from .node import ContinuousRandomVariableNode, DataNode, DiscreteRandomVariableNode
@@ -198,7 +196,7 @@ def build_learn_initialiser(
     r_hat_i: NDArray,
     *,
     evaluation_points_axes_mapping: dict | None = None,
-) -> MLPAlias:
+) -> Callable[[ModelParam], jax.Array]:
     r"""
     Construct the function $B(\theta)$.
 
@@ -278,50 +276,3 @@ def build_learn_initialiser(
         return ((r_hat_i - r_theta) ** 2).sum() / n_eval
 
     return _objective_function
-
-
-def learn_initialiser(
-    r: MLPAlias,
-    evaluation_points: dict[str, NDArray],
-    r_hat_i: NDArray,
-    *,
-    evaluation_points_axes_mapping: dict | None = None,
-    solver: Callable | None = None,
-    solver_args: tuple = (),
-    solver_kwargs: dict[str, Any] | None = None,
-) -> SolverResult:
-    r"""
-    Construct the function $B(\theta)$, and compute it's argmin.
-
-    This function essentially wraps `build_learn_initialiser`. See that method's
-    documentation for information on the non-solver-related input arguments.
-
-    Once $B$ is constructed, `solver` will be used to determine it's argmin, returning
-    the `SolverResult`.
-
-    Args:
-        r: Regression function, $r$. Typically the output of `build_regression_function`
-        evaluation_points: Set of evaluation points, $\mathcal{D}$
-        r_hat_i: The values of the estimate of r at the evaluation points, $\hat{r}_i$
-        evaluation_points_axes_mapping: Axes to vectorise over when evaluating $r$
-            at the `evaluation_points`.
-        solver: Minimisation method, defined as a Python callable. It should accept
-            the objective function as it's first argument. Default is
-            `causalprog.solvers.sgd.stochastic_gradient_descent`.
-        solver_args: Positional arguments to pass to the `solver`.
-        solver_kwargs: Keyword arguments to pass to the `solver`.
-
-    """
-    if solver is None:
-        solver = stochastic_gradient_descent
-    if solver_kwargs is None:
-        solver_kwargs = {}
-
-    obj_fn = build_learn_initialiser(
-        r,
-        evaluation_points,
-        r_hat_i,
-        evaluation_points_axes_mapping=evaluation_points_axes_mapping,
-    )
-
-    return solver(obj_fn, *solver_args, **solver_kwargs)

--- a/src/causalprog/graph/ricardo.py
+++ b/src/causalprog/graph/ricardo.py
@@ -192,18 +192,15 @@ def build_regression_function(
     return _r
 
 
-def learn_initialiser(
+def build_learn_initialiser(
     r: MLPAlias,
     evaluation_points: dict[str, NDArray],
     r_hat_i: NDArray,
     *,
     evaluation_points_axes_mapping: dict | None = None,
-    solver: Callable | None = None,
-    solver_args: tuple = (),
-    solver_kwargs: dict[str, Any] | None = None,
-) -> SolverResult:
+) -> MLPAlias:
     r"""
-    Compute the argmin of the function $B(\theta)$.
+    Construct the function $B(\theta)$.
 
     $$ B(\theta) = \frac{1}{N}\sum_i^N \left( \hat{r}_i - r_i(\theta) \right)^2, $$
 
@@ -261,17 +258,8 @@ def learn_initialiser(
         r_hat_i: The values of the estimate of r at the evaluation points, $\hat{r}_i$
         evaluation_points_axes_mapping: Axes to vectorise over when evaluating $r$
             at the `evaluation_points`.
-        solver: Minimisation method, defined as a Python callable. It should accept
-            the objective function as it's first argument. Default is
-            `causalprog.solvers.sgd.stochastic_gradient_descent`.
-        solver_args: Positional arguments to pass to the `solver`.
-        solver_kwargs: Keyword arguments to pass to the `solver`.
 
     """
-    if solver is None:
-        solver = stochastic_gradient_descent
-    if solver_kwargs is None:
-        solver_kwargs = {}
     if evaluation_points_axes_mapping is None:
         evaluation_points_axes_mapping = {}
 
@@ -289,4 +277,51 @@ def learn_initialiser(
         r_theta = vectorised_r(evaluation_points, theta)
         return ((r_hat_i - r_theta) ** 2).sum() / n_eval
 
-    return solver(_objective_function, *solver_args, **solver_kwargs)
+    return _objective_function
+
+
+def learn_initialiser(
+    r: MLPAlias,
+    evaluation_points: dict[str, NDArray],
+    r_hat_i: NDArray,
+    *,
+    evaluation_points_axes_mapping: dict | None = None,
+    solver: Callable | None = None,
+    solver_args: tuple = (),
+    solver_kwargs: dict[str, Any] | None = None,
+) -> SolverResult:
+    r"""
+    Construct the function $B(\theta)$, and compute it's argmin.
+
+    This function essentially wraps `build_learn_initialiser`. See that method's
+    documentation for information on the non-solver-related input arguments.
+
+    Once $B$ is constructed, `solver` will be used to determine it's argmin, returning
+    the `SolverResult`.
+
+    Args:
+        r: Regression function, $r$. Typically the output of `build_regression_function`
+        evaluation_points: Set of evaluation points, $\mathcal{D}$
+        r_hat_i: The values of the estimate of r at the evaluation points, $\hat{r}_i$
+        evaluation_points_axes_mapping: Axes to vectorise over when evaluating $r$
+            at the `evaluation_points`.
+        solver: Minimisation method, defined as a Python callable. It should accept
+            the objective function as it's first argument. Default is
+            `causalprog.solvers.sgd.stochastic_gradient_descent`.
+        solver_args: Positional arguments to pass to the `solver`.
+        solver_kwargs: Keyword arguments to pass to the `solver`.
+
+    """
+    if solver is None:
+        solver = stochastic_gradient_descent
+    if solver_kwargs is None:
+        solver_kwargs = {}
+
+    obj_fn = build_learn_initialiser(
+        r,
+        evaluation_points,
+        r_hat_i,
+        evaluation_points_axes_mapping=evaluation_points_axes_mapping,
+    )
+
+    return solver(obj_fn, *solver_args, **solver_kwargs)

--- a/tests/test_integration/test_ricardo/test_learn_initialiser.py
+++ b/tests/test_integration/test_ricardo/test_learn_initialiser.py
@@ -5,56 +5,39 @@ import pytest
 from causalprog.graph.ricardo import MLPAlias, ModelParam, build_learn_initialiser
 from causalprog.solvers.sgd import stochastic_gradient_descent
 
-# FIXME: adapt these tests so that they are more meaningful.
-# We might not actually need to do the solve every single time to check things...
-
 
 @pytest.mark.parametrize(
-    ("opt_args", "opt_kwargs", "expected_solution"),
+    ("call_initialiser_at", "expected_residual"),
     [
+        pytest.param({"a": 1.0, "b": 0.0, "c": -1.0}, 0.0, id="Call at optimal theta"),
         pytest.param(
-            ({"a": 1.5, "b": 0.5, "c": -0.5},),
-            {
-                "convergence_criteria": lambda x, _: jnp.sqrt(jnp.abs(x)),
-                "tolerance": 1e-6,
-            },
-            {"a": 2.0, "b": 1.0, "c": -1.0},
-            id="SDG: Solution basin 1",
+            {"a": 0.0, "b": 1.0, "c": -1.0}, 0.0, id="Call at equivalent optimal theta"
         ),
         pytest.param(
-            ({"a": 0.5, "b": 1.5, "c": -0.5},),
-            {
-                "convergence_criteria": lambda x, _: jnp.sqrt(jnp.abs(x)),
-                "tolerance": 1e-6,
-            },
-            {"a": 1.0, "b": 2.0, "c": -1.0},
-            id="SDG: Solution basin 2 (switch initial guess params)",
+            {"a": 1.0, "b": 0.0, "c": -0.5},
+            74.0 / 64.0 / 5.0,
+            id="Actually evaluates residual",
         ),
     ],
 )
 def test_learn_initialiser_deterministic_fn(
-    opt_args, opt_kwargs, expected_solution, pytree_allclose
+    call_initialiser_at: ModelParam,
+    expected_residual: float,
+    r: MLPAlias = lambda data, theta: (
+        (data["x"] - theta["a"]) * (data["x"] - theta["b"]) * (data["x"] - theta["c"])
+    ),
 ) -> None:
-    """Test that `learn_initialiser` correctly 'learns' the parameters of a
-    deterministic function.
+    """Simple explicit-evaluation test for the function constructed by
+    `learn_initialiser`.
     """
-    theta_opt = {"a": 1.0, "b": 2.0, "c": -1.0}
+    theta_opt = {"a": 1.0, "b": 0.0, "c": -1.0}
+    eval_pts = {"x": jnp.linspace(-1.0, 1.0, num=5)}
+    r_hat_pts = r(eval_pts, theta_opt)
 
-    def _r(data, theta):
-        return (
-            (data["x"] - theta["a"])
-            * (data["x"] - theta["b"])
-            * (data["x"] - theta["c"])
-        )
+    learn_initialiser = build_learn_initialiser(r, eval_pts, r_hat_pts)
+    residual = learn_initialiser(call_initialiser_at)
 
-    eval_pts = {"x": jnp.linspace(-5.0, 5.0, num=25)}
-    r_hat_pts = _r(eval_pts, theta_opt)
-
-    learn_initialiser = build_learn_initialiser(_r, eval_pts, r_hat_pts)
-    result = stochastic_gradient_descent(learn_initialiser, *opt_args, **opt_kwargs)
-
-    assert result.successful
-    assert pytree_allclose(result.fn_args, expected_solution)
+    assert jnp.allclose(residual, expected_residual)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration/test_ricardo/test_learn_initialiser.py
+++ b/tests/test_integration/test_ricardo/test_learn_initialiser.py
@@ -2,14 +2,14 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from causalprog.graph.ricardo import MLPAlias, ModelParam, learn_initialiser
+from causalprog.graph.ricardo import MLPAlias, ModelParam, build_learn_initialiser
+from causalprog.solvers.sgd import stochastic_gradient_descent
 
 
 @pytest.mark.parametrize(
-    ("optimiser", "opt_args", "opt_kwargs", "expected_solution"),
+    ("opt_args", "opt_kwargs", "expected_solution"),
     [
         pytest.param(
-            None,
             ({"a": 1.5, "b": 0.5, "c": -0.5},),
             {
                 "convergence_criteria": lambda x, _: jnp.sqrt(jnp.abs(x)),
@@ -19,7 +19,6 @@ from causalprog.graph.ricardo import MLPAlias, ModelParam, learn_initialiser
             id="SDG: Solution basin 1",
         ),
         pytest.param(
-            None,
             ({"a": 0.5, "b": 1.5, "c": -0.5},),
             {
                 "convergence_criteria": lambda x, _: jnp.sqrt(jnp.abs(x)),
@@ -31,7 +30,7 @@ from causalprog.graph.ricardo import MLPAlias, ModelParam, learn_initialiser
     ],
 )
 def test_learn_initialiser_deterministic_fn(
-    optimiser, opt_args, opt_kwargs, expected_solution, pytree_allclose
+    opt_args, opt_kwargs, expected_solution, pytree_allclose
 ) -> None:
     """Test that `learn_initialiser` correctly 'learns' the parameters of a
     deterministic function.
@@ -48,14 +47,8 @@ def test_learn_initialiser_deterministic_fn(
     eval_pts = {"x": jnp.linspace(-5.0, 5.0, num=25)}
     r_hat_pts = _r(eval_pts, theta_opt)
 
-    result = learn_initialiser(
-        _r,
-        eval_pts,
-        r_hat_pts,
-        solver=optimiser,
-        solver_args=opt_args,
-        solver_kwargs=opt_kwargs,
-    )
+    learn_initialiser = build_learn_initialiser(_r, eval_pts, r_hat_pts)
+    result = stochastic_gradient_descent(learn_initialiser, *opt_args, **opt_kwargs)
 
     assert result.successful
     assert pytree_allclose(result.fn_args, expected_solution)
@@ -136,13 +129,13 @@ def test_learn_initialiser_evaluation_points_axes_mapping(
 
     # Since we're only checking array dimension matching,
     # start the solver at the solution to immediately terminate.
-    result = learn_initialiser(
+    learn_initialiser = build_learn_initialiser(
         _r,
         eval_pts,
         r_hat_pts,
         evaluation_points_axes_mapping=eval_pts_mapping,
-        solver_args=(expected_solution,),
     )
+    result = stochastic_gradient_descent(learn_initialiser, expected_solution)
 
     assert result.successful
     assert pytree_all_same_shape(result.fn_args, expected_solution)
@@ -236,13 +229,16 @@ def test_learn_initialiser_uy_independent_regression_fn(
 
     expected_solution = dict(initial_guess)
     expected_solution["theta_y"] = theta_y_solution
-    result = learn_initialiser(
+    learn_initialiser = build_learn_initialiser(
         r,
         evaluation_points,
         r_hat_pts,
         evaluation_points_axes_mapping=evaluation_points_mapping,
-        solver_args=(initial_guess,),
-        solver_kwargs=opt_kwargs,
+    )
+    result = stochastic_gradient_descent(
+        learn_initialiser,
+        initial_guess,
+        **opt_kwargs,
     )
 
     assert result.successful
@@ -347,13 +343,16 @@ def test_learn_initialiser_ux_independent_regression_fn(
         evaluation_points, expected_solution
     )
 
-    result = learn_initialiser(
+    learn_initialiser = build_learn_initialiser(
         r,
         evaluation_points,
         r_hat_pts,
         evaluation_points_axes_mapping=evaluation_points_mapping,
-        solver_args=(initial_guess,),
-        solver_kwargs=opt_kwargs,
+    )
+    result = stochastic_gradient_descent(
+        learn_initialiser,
+        initial_guess,
+        **opt_kwargs,
     )
 
     assert result.successful

--- a/tests/test_integration/test_ricardo/test_learn_initialiser.py
+++ b/tests/test_integration/test_ricardo/test_learn_initialiser.py
@@ -5,6 +5,9 @@ import pytest
 from causalprog.graph.ricardo import MLPAlias, ModelParam, build_learn_initialiser
 from causalprog.solvers.sgd import stochastic_gradient_descent
 
+# FIXME: adapt these tests so that they are more meaningful.
+# We might not actually need to do the solve every single time to check things...
+
 
 @pytest.mark.parametrize(
     ("opt_args", "opt_kwargs", "expected_solution"),
@@ -54,92 +57,94 @@ def test_learn_initialiser_deterministic_fn(
     assert pytree_allclose(result.fn_args, expected_solution)
 
 
-def _n_eval() -> int:
-    """Magic number function for the number of evaluation points in tests.
-
-    `pytest` fixtures cannot be evaluated as part of a parameter value. As such,
-    in order to avoid magic numbers everywhere, we have a hidden function to
-    fix a value for the number of evaluation points to use.
-    """
-    return 5
-
-
 @pytest.mark.parametrize(
-    (
-        "eval_pts",
-        "eval_pts_mapping",
-        "r_hat_pts",
-        "expected_solution",
-    ),
+    ("axes_mapping", "expected_values"),
     [
         pytest.param(
-            {"x": jnp.linspace(-1.0, 1.0, num=_n_eval())},
             None,
-            jnp.zeros(_n_eval()),
-            {"a": 0.0, "b": 0.0},
-            id="Standard scalar inputs.",
+            jnp.array(
+                (11.0 / 100.0) ** 2
+                * ((0 + 1 + 2) ** 2 + (3 + 4 + 5) ** 2 + (6 + 7 + 8) ** 2)
+                / 3
+            ),
+            id="Default map along axes 0",
         ),
         pytest.param(
-            {"x": jnp.tile(jnp.linspace(-1.0, 1.0, num=_n_eval()), (3, 1))},
+            {"x": 0, "y": 0},
+            jnp.array(
+                (11.0 / 100.0) ** 2
+                * ((0 + 1 + 2) ** 2 + (3 + 4 + 5) ** 2 + (6 + 7 + 8) ** 2)
+                / 3
+            ),
+            id="Explicit map along axes 0",
+        ),
+        pytest.param(
+            {"x": 1, "y": 1},
+            jnp.array(
+                (11.0 / 100.0) ** 2
+                * ((0 + 3 + 6) ** 2 + (1 + 4 + 7) ** 2 + (2 + 5 + 8) ** 2)
+                / 3
+            ),
+            id="Map along axes 1",
+        ),
+        pytest.param(
             {"x": 1},
-            jnp.ones(_n_eval()),
-            {"a": 1.0, "b": jnp.zeros(3)},
-            id="Vector-valued data",
+            jnp.array(
+                (
+                    ((0 + 3 + 6) / 10 + (0 + 1 + 2) / 100) ** 2
+                    + ((1 + 4 + 7) / 10 + (3 + 4 + 5) / 100) ** 2
+                    + ((2 + 5 + 8) / 10 + (6 + 7 + 8) / 100) ** 2
+                )
+                / 3
+            ),
+            id="x along 1, y along 0",
         ),
         pytest.param(
-            {"x": jnp.tile(jnp.linspace(-1.0, 1.0, num=_n_eval()), (3, 1)).T},
-            {"x": 0},
-            jnp.ones(_n_eval()),
-            {"a": 1.0, "b": jnp.zeros(3)},
-            id="Vector-valued data, transposed",
-        ),
-        pytest.param(
-            {"x": jnp.tile(jnp.linspace(-1.0, 1.0, num=_n_eval()), (3, 4, 1))},
-            {"x": 2},
-            jnp.ones(_n_eval()),
-            {"a": 1.0, "b": jnp.zeros((3, 4))},
-            id="Matrix-valued data",
-        ),
-        pytest.param(
-            {"x": jnp.tile(jnp.linspace(-1.0, 1.0, num=_n_eval()), (3, 1))},
-            {"x": 1},
-            jnp.array([6.0, 9.0 / 4.0, 1.0, 9.0 / 4.0, 6.0]),
-            {"a": 1.0, "b": jnp.array([2.0, 1.0, 0.0])},
-            id="Non-trivial problem",
+            {"y": 1},
+            jnp.array(
+                (
+                    ((0 + 3 + 6) / 100 + (0 + 1 + 2) / 10) ** 2
+                    + ((1 + 4 + 7) / 100 + (3 + 4 + 5) / 10) ** 2
+                    + ((2 + 5 + 8) / 100 + (6 + 7 + 8) / 10) ** 2
+                )
+                / 3
+            ),
+            id="x along 0, y along 1",
         ),
     ],
 )
 def test_learn_initialiser_evaluation_points_axes_mapping(
-    eval_pts: dict[str, jax.Array],
-    eval_pts_mapping: dict[str, int],
-    r_hat_pts: jax.Array,
-    expected_solution: dict[str, jax.Array | float],
-    pytree_allclose,
-    pytree_all_same_shape,
+    axes_mapping: dict[str, int],
+    expected_values: jax.Array,
+    r: MLPAlias = lambda data, _: data["x"].sum() + data["y"].sum(),
 ) -> None:
-    """Check that `evaluation_points_axes_mapping` is respected.
+    """Check that the axes mapping for input evaluation points is respected.
 
-    This is tested by passing in data of various sizes, and confirming that the
-    optimisation still runs and the resulting output has the expected shape for
-    the $\theta$ parameters.
+    To do so, we use a fixed r-function and let the r_hat_i points all be 0.
+    This effectively gives us a function B that is just the sum of the squares
+    of the r-function at the evaluation points times a constant, which we can then
+    check the value of (when evaluated) to confirm that the evaluation points are mapped
+    correctly.
     """
+    eval_pts = {
+        "x": 0.1 * jnp.arange(9).reshape(3, 3),
+        "y": 0.01 * jnp.arange(9).reshape(3, 3),
+    }
+    if axes_mapping is not None:
+        n_eval_pts = eval_pts["x"].shape[axes_mapping.get("x", 0)]
+    else:
+        n_eval_pts = eval_pts["x"].shape[0]
 
-    def _r(data, theta):
-        return ((theta["b"] * data["x"]) ** 2).sum() + theta["a"]
+    r_hat_pts = jnp.zeros((n_eval_pts,))
 
-    # Since we're only checking array dimension matching,
-    # start the solver at the solution to immediately terminate.
     learn_initialiser = build_learn_initialiser(
-        _r,
+        r,
         eval_pts,
         r_hat_pts,
-        evaluation_points_axes_mapping=eval_pts_mapping,
+        evaluation_points_axes_mapping=axes_mapping,
     )
-    result = stochastic_gradient_descent(learn_initialiser, expected_solution)
 
-    assert result.successful
-    assert pytree_all_same_shape(result.fn_args, expected_solution)
-    assert pytree_allclose(result.fn_args, expected_solution)
+    assert jnp.allclose(learn_initialiser({}), expected_values)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Relates to #164 |

#160 introduced the `learn_initialiser` method, but that method returned the arg-min of the objective function $B$ rather than the function $B$ itself. However we will require access to the function $B$ when we come to determine the bounds for the causal response function, and need to use $B$ in the constraints of this problem.

As such, `learn_initaliser` has been renamed to `build_loss_function`, and now just returns the loss function $B$ directly, without attempting to determine the arg-min. This effectively bypasses the issue in #164 since we're now delegating the task of finding the arg-min to the user one they build this function.

This change also makes #133 slightly easier to handle, since the form for $B$ can itself now be an input to `build_loss_function` if we wanted to go that route (with the default being our current sum-of-squares-residual).