### PR TITLE
Expose inner SGD options in constrained solvers

### DIFF
--- a/src/causalprog/solvers/augmented_lagrangian.py
+++ b/src/causalprog/solvers/augmented_lagrangian.py
@@ -25,6 +25,7 @@ def minimise(
     convergence_criterion: Callable[[PyTree, PyTree], jax.Array] | None = None,
     fn_args: tuple = (),
     fn_kwargs: dict | None = None,
+    sgd_kwargs: dict | None = None,
     maxiter: int = 10,
     tolerance: float = 1.0e-8,
     history_logging_interval: int = -1,
@@ -54,6 +55,9 @@ def minimise(
             solutions.
         fn_args: Positional arguments to be passed to `obj_fn`, and held constant.
         fn_kwargs: Keyword arguments to be passed to `obj_fn`, and held constant.
+        sgd_kwargs: Keyword arguments passed to the inner
+            `stochastic_gradient_descent` solve. `fn_args` and `fn_kwargs` are
+            managed internally and cannot be supplied here.
         maxiter: Maximum number of iterations to perform. An error will be reported if
             this number of iterations is exceeded.
         tolerance: `tolerance` used when determining if a minimum has been found.
@@ -71,6 +75,11 @@ def minimise(
     """
     if fn_kwargs is None:
         fn_kwargs = {}
+    if sgd_kwargs is None:
+        sgd_kwargs = {}
+    if {"fn_args", "fn_kwargs"} & sgd_kwargs.keys():
+        msg = "sgd_kwargs cannot contain fn_args or fn_kwargs."
+        raise ValueError(msg)
     if convergence_criterion is None:
         convergence_criterion = lambda a, b: jnp.sqrt(  # noqa: E731
             sum(l2_normsq(b[i] - a[i]) for i in b)
@@ -112,11 +121,10 @@ def minimise(
 
     for current_iter in range(maxiter):
         previous_solution = current_solution
+        inner_sgd_kwargs = {"learning_rate": 1 / mu, **sgd_kwargs}
+        inner_sgd_kwargs["fn_kwargs"] = {"mu": mu, "lamb": lamb}
         current_solution = stochastic_gradient_descent(
-            objective,
-            current_solution,
-            fn_kwargs={"mu": mu, "lamb": lamb},
-            learning_rate=1 / mu,
+            objective, current_solution, **inner_sgd_kwargs
         ).fn_args
         lamb += mu * evaluate_bounds(current_solution)
         mu = update_mu(mu)

--- a/src/causalprog/solvers/penalty.py
+++ b/src/causalprog/solvers/penalty.py
@@ -25,6 +25,7 @@ def minimise(
     convergence_criterion: Callable[[PyTree, PyTree], jax.Array] | None = None,
     fn_args: tuple = (),
     fn_kwargs: dict | None = None,
+    sgd_kwargs: dict | None = None,
     maxiter: int = 10,
     tolerance: float = 1.0e-8,
     history_logging_interval: int = -1,
@@ -52,6 +53,9 @@ def minimise(
             solutions.
         fn_args: Positional arguments to be passed to `obj_fn`, and held constant.
         fn_kwargs: Keyword arguments to be passed to `obj_fn`, and held constant.
+        sgd_kwargs: Keyword arguments passed to the inner
+            `stochastic_gradient_descent` solve. `fn_args` and `fn_kwargs` are
+            managed internally and cannot be supplied here.
         maxiter: Maximum number of iterations to perform. An error will be reported if
             this number of iterations is exceeded.
         tolerance: `tolerance` used when determining if a minimum has been found.
@@ -69,6 +73,11 @@ def minimise(
     """
     if fn_kwargs is None:
         fn_kwargs = {}
+    if sgd_kwargs is None:
+        sgd_kwargs = {}
+    if {"fn_args", "fn_kwargs"} & sgd_kwargs.keys():
+        msg = "sgd_kwargs cannot contain fn_args or fn_kwargs."
+        raise ValueError(msg)
     if convergence_criterion is None:
         convergence_criterion = lambda a, b: jnp.sqrt(  # noqa: E731
             sum(l2_normsq(b[i] - a[i]) for i in b)
@@ -105,8 +114,10 @@ def minimise(
 
     for current_iter in range(maxiter):
         previous_solution = current_solution
+        inner_sgd_kwargs = {"learning_rate": 1 / mu, **sgd_kwargs}
+        inner_sgd_kwargs["fn_kwargs"] = {"mu": mu}
         current_solution = stochastic_gradient_descent(
-            objective, current_solution, fn_kwargs={"mu": mu}, learning_rate=1 / mu
+            objective, current_solution, **inner_sgd_kwargs
         ).fn_args
         mu = update_mu(mu)
 

--- a/tests/test_solvers/test_augmented_lagrangian.py
+++ b/tests/test_solvers/test_augmented_lagrangian.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import pytest
 
 from causalprog.solvers import augmented_lagrangian
+from causalprog.solvers.solver_result import SolverResult
 
 
 def f(x: dict[str, jax.Array]) -> jax.Array:
@@ -32,6 +33,38 @@ def test_maximise():
     assert jnp.isclose(max_solution.fn_args["x1"], min_solution.fn_args["x1"])
     assert jnp.isclose(max_solution.fn_args["x2"], min_solution.fn_args["x2"])
     assert jnp.isclose(max_solution.obj_val, 5.0 - min_solution.obj_val)
+
+
+def test_minimise_forwards_sgd_kwargs(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_sgd(_objective, initial_guess, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SolverResult(
+            fn_args=initial_guess,
+            iters=0,
+            maxiter=kwargs["maxiter"],
+            obj_val=0.0,
+            reason="",
+            successful=True,
+        )
+
+    monkeypatch.setattr(
+        augmented_lagrangian, "stochastic_gradient_descent", fake_sgd
+    )
+
+    augmented_lagrangian.minimise(
+        f,
+        {"x1": 0.0, "x2": 0.0},
+        bounds,
+        maxiter=1,
+        sgd_kwargs={"learning_rate": 0.25, "maxiter": 7, "tolerance": 1e-4},
+    )
+
+    assert captured_kwargs["learning_rate"] == 0.25
+    assert captured_kwargs["maxiter"] == 7
+    assert captured_kwargs["tolerance"] == 1e-4
+    assert captured_kwargs["fn_kwargs"] == {"mu": 1.0, "lamb": jnp.zeros(1)}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_solvers/test_penalty.py
+++ b/tests/test_solvers/test_penalty.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import pytest
 
 from causalprog.solvers import penalty
+from causalprog.solvers.solver_result import SolverResult
 
 
 def f(x: dict[str, jax.Array]) -> jax.Array:
@@ -32,6 +33,36 @@ def test_maximise():
     assert jnp.isclose(max_solution.fn_args["x1"], min_solution.fn_args["x1"])
     assert jnp.isclose(max_solution.fn_args["x2"], min_solution.fn_args["x2"])
     assert jnp.isclose(max_solution.obj_val, 5.0 - min_solution.obj_val)
+
+
+def test_minimise_forwards_sgd_kwargs(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_sgd(_objective, initial_guess, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SolverResult(
+            fn_args=initial_guess,
+            iters=0,
+            maxiter=kwargs["maxiter"],
+            obj_val=0.0,
+            reason="",
+            successful=True,
+        )
+
+    monkeypatch.setattr(penalty, "stochastic_gradient_descent", fake_sgd)
+
+    penalty.minimise(
+        f,
+        {"x1": 0.0, "x2": 0.0},
+        bounds,
+        maxiter=1,
+        sgd_kwargs={"learning_rate": 0.25, "maxiter": 7, "tolerance": 1e-4},
+    )
+
+    assert captured_kwargs["learning_rate"] == 0.25
+    assert captured_kwargs["maxiter"] == 7
+    assert captured_kwargs["tolerance"] == 1e-4
+    assert captured_kwargs["fn_kwargs"] == {"mu": 1.0}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add an `sgd_kwargs` option to the penalty and augmented Lagrangian solvers so callers can configure the inner stochastic-gradient-descent solve. Internal objective arguments remain protected while options such as learning rate, iteration limit, tolerance, optimiser, callbacks, and logging can be forwarded.

## Tests

```
uv run --extra test pytest tests/test_solvers/test_penalty.py tests/test_solvers/test_augmented_lagrangian.py -q
uv run ruff check src/causalprog/solvers/penalty.py src/causalprog/solvers/augmented_lagrangian.py tests/test_solvers/test_penalty.py tests/test_solvers/test_augmented_lagrangian.py
uv run ruff format --check src/causalprog/solvers/penalty.py src/causalprog/solvers/augmented_lagrangian.py tests/test_solvers/test_penalty.py tests/test_solvers/test_augmented_lagrangian.py
```

Fixes #179