### PR TITLE
Remove Matt Graham from project team / author lists

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,10 +3,6 @@ message: "If you use this software, please cite it as below."
 type: software
 authors:
   - family-names: "Graham"
-    given-names: "Matthew M."
-    affiliation: "University College London"
-    orcid: "https://orcid.org/0000-0001-9104-7960"
-  - family-names: "Graham"
     given-names: "William"
     affiliation: "University College London"
     orcid: "https://orcid.org/0000-0003-0058-263X"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The package also provides some basic wrappers for these solvers, for the most co
 - Will Graham ([willGraham01](https://github.com/willGraham01))
 - Matthew Scroggs ([mscroggs](https://github.com/mscroggs))
 - Sam Molyneux ([sjmolyneux](https://github.com/samjmolyneux))
-- Matt Graham ([matt-graham](https://github.com/matt-graham))
 
 ### Research software engineering contact
 


### PR DESCRIPTION
My name ended up in project team and citation file metadata as I set up the initial repository using the [UCL-ARC/python-tooling](https://github.com/UCL-ARC/python-tooling/) template and it was possible at that point I would have more involvement in project, but I haven't made any further substantive contributions since so I don't think I need to be included as an author.