### PR TITLE
Allow discrete random variables to use range values

### DIFF
--- a/src/causalprog/graph/node/random_variables.py
+++ b/src/causalprog/graph/node/random_variables.py
@@ -116,7 +116,7 @@ class DiscreteRandomVariableNode(RandomVariableNode):
     def __init__(
         self,
         *,
-        values: list[float] | list[npt.NDArray[float]],
+        values: list[float] | list[npt.NDArray[float]] | range,
         shape: tuple[int, ...] = (),
         label: str,
         compute: typing.Callable | None = None,
@@ -125,6 +125,7 @@ class DiscreteRandomVariableNode(RandomVariableNode):
         Initialise.
 
         Args:
+            values: The possible values of the random variable
             shape: The shape of the output of the RV
             label: A unique label to identify the node
             compute: A function to compute node's value from given values of parents
@@ -134,7 +135,7 @@ class DiscreteRandomVariableNode(RandomVariableNode):
         self._values = values
 
     @property
-    def possible_values(self) -> list[float] | list[npt.NDArray[float]]:
+    def possible_values(self) -> list[float] | list[npt.NDArray[float]] | range:
         """The values that this RV can take."""
         return self._values
 
@@ -144,6 +145,16 @@ class DiscreteRandomVariableNode(RandomVariableNode):
 
     @override
     def is_valid_value(self, value: float | npt.NDArray[float]) -> bool:
+        if isinstance(self._values, range):
+            scalar = np.asarray(value)
+            if scalar.ndim != 0:
+                return False
+            scalar_value = scalar.item()
+            if isinstance(scalar_value, float):
+                if not scalar_value.is_integer():
+                    return False
+                scalar_value = int(scalar_value)
+            return scalar_value in self._values
         return any(np.allclose(v, value) for v in self._values)
 
     @override

--- a/tests/test_node/test_random_variables.py
+++ b/tests/test_node/test_random_variables.py
@@ -28,6 +28,16 @@ def test_invalid_discrete_node_value(raises_context):
         node.evaluate({"Y": -1.0})
 
 
+def test_discrete_node_range_values(raises_context):
+    values = range(10**20)
+    node = DiscreteRandomVariableNode(label="Y", values=values)
+
+    assert node.possible_values is values
+    assert node.evaluate({"Y": 10**20 - 1}) == 10**20 - 1
+    with raises_context(ValueError("Invalid value for DiscreteRandomVariableNode")):
+        node.evaluate({"Y": 10**20})
+
+
 def test_evaluate_down_graph():
     graph = Graph(label="G")
 


### PR DESCRIPTION
## Summary

- allow `DiscreteRandomVariableNode.values` to accept a `range` without materializing it
- validate range-backed scalar values with constant-time membership checks
- add regression coverage for a range up to `10**20`

Closes #182

## Testing

- `pytest -p tests.fixtures.general --confcutdir=tests/test_node tests/test_node/test_random_variables.py` (5 passed)
- `ruff check src/causalprog/graph/node/random_variables.py tests/test_node/test_random_variables.py`
- `ruff format --check src/causalprog/graph/node/random_variables.py tests/test_node/test_random_variables.py`
- boundary checks for integral floats, scalar arrays, non-integral floats, array values, and upper-bound rejection