### PR TITLE
fix softmax `pi_ul(c)` bug

### DIFF
--- a/src/causalprog/graph/ricardo.py
+++ b/src/causalprog/graph/ricardo.py
@@ -145,9 +145,9 @@ def build_regression_function(
         """
         return node_ux.compute(xzl, theta_x)
 
-    def pi_ul(ulc: dict[str, NDArray], theta_pi: ModelParam) -> NDArray:
-        r"""$\pi_ul(c, u, l; \theta_{\pi})."""
-        return softmax(node_uy.compute(ulc, theta_pi))
+    def pi_ul(ul: dict[str, NDArray], theta_pi: ModelParam) -> NDArray:
+        r"""$\pi_{ul}(u, l; \theta_{\pi})."""
+        return softmax(node_uy.compute(ul, theta_pi))
 
     def f_y(x_uy: dict[str, NDArray], theta_y: ModelParam) -> float | NDArray:
         r"""$f_Y(x, u_y; \theta_Y)."""
@@ -172,6 +172,8 @@ def build_regression_function(
         z = xzl["z"]
         el = xzl["l"]
 
+        pi_ul_predictions = pi_ul({"l": el, "u_x": u}, theta_pi)
+
         result = 0.0
         for i_c, c in enumerate(c_values):
             czl = {"c": c, "z": z, "l": el}
@@ -182,9 +184,8 @@ def build_regression_function(
             m_y = jnp.dot(u, sigmoid_f_m * f_r_vector / norm(f_r_vector))
             u_y = s_q * jnp.sqrt(v_y) + m_y
 
-            pi_ul_prediction = pi_ul({"c": c, "l": el, "u_x": u}, theta_pi)[i_c]
             f_y_prediction = f_y({"x": x, "u_y": u_y, "l": el}, theta_y)
-            result += pi_ul_prediction * f_y_prediction
+            result += pi_ul_predictions[i_c] * f_y_prediction
         return result
 
     def _r(

--- a/tests/fixtures/ricardo.py
+++ b/tests/fixtures/ricardo.py
@@ -89,7 +89,7 @@ def uy_independent_mlps() -> Callable[[int], tuple[dict[str, MLPAlias], MLPAlias
             "f_r": lambda czl, theta_m: theta_m * jnp.ones_like(czl["z"]),
             "f_m": lambda czl, theta_r: czl["c"] * theta_r,
             "f_ux": lambda xzl, theta_x: xzl["x"] * theta_x[0],
-            "f_pi": lambda ucl, theta_pi: theta_pi + ucl["u_x"] * jnp.arange(k_len),
+            "f_pi": lambda ul, theta_pi: theta_pi + ul["u_x"] * jnp.arange(k_len),
             "f_y": lambda xu_y, theta_y: theta_y[0] * jnp.exp(-(xu_y["x"] ** 2)),
         }, lambda xzl, theta: theta["theta_y"][0] * jnp.exp(-(xzl["x"] ** 2))
 

--- a/tests/fixtures/ricardo.py
+++ b/tests/fixtures/ricardo.py
@@ -89,9 +89,7 @@ def uy_independent_mlps() -> Callable[[int], tuple[dict[str, MLPAlias], MLPAlias
             "f_r": lambda czl, theta_m: theta_m * jnp.ones_like(czl["z"]),
             "f_m": lambda czl, theta_r: czl["c"] * theta_r,
             "f_ux": lambda xzl, theta_x: xzl["x"] * theta_x[0],
-            "f_pi": lambda ucl, theta_pi: (
-                theta_pi * ucl["c"] + ucl["u_x"] * jnp.arange(k_len)
-            ),
+            "f_pi": lambda ucl, theta_pi: theta_pi + ucl["u_x"] * jnp.arange(k_len),
             "f_y": lambda xu_y, theta_y: theta_y[0] * jnp.exp(-(xu_y["x"] ** 2)),
         }, lambda xzl, theta: theta["theta_y"][0] * jnp.exp(-(xzl["x"] ** 2))
 

--- a/tests/test_integration/test_ricardo/test_regression_function.py
+++ b/tests/test_integration/test_ricardo/test_regression_function.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from causalprog.graph.ricardo import MLPAlias
 
@@ -121,3 +122,65 @@ def test_uy_independent_of_ux(
     r_direct = vectorise_over_dict_args(r_direct_integration, xzl.keys(), theta.keys())
 
     assert jnp.allclose(r(xzl, theta), r_direct(xzl, theta))
+
+
+def test_regression_correctly_calculates_pi_ul(
+    ricardo_regression_function,
+    k_len: int = 3,
+    z_len: int = 1,
+    n_points: int = 10,
+) -> None:
+    r"""The regression function must use one shared vector of mixture probabilities.
+
+    Setting $f_Y=1$ means
+
+    $$
+    r(x,z,l)
+    =
+    \sum_{c=1}^{K}\pi_{ul}(c).
+    $$
+
+    Therefore, the result must equal one.
+    """
+    rng = np.random.default_rng()
+
+    def f_pi(ul: dict, _theta_pi):  # noqa: ARG001
+        """Produce a unique array each time"""
+        return jnp.asarray(rng.normal(size=k_len))
+
+    def f_ux(xzl: dict, theta_x):
+        return xzl["x"] * theta_x
+
+    def f_r(czl: dict, _theta_r):
+        return jnp.ones_like(czl["z"])
+
+    def f_m(_czl: dict, _theta_m):
+        return jnp.asarray(0.0)
+
+    def f_y(_xuy: dict, _theta_y):
+        return jnp.asarray(1.0)
+
+    r = ricardo_regression_function(
+        k_len=k_len,
+        z_len=z_len,
+        f_ux=f_ux,
+        f_pi=f_pi,
+        f_y=f_y,
+        f_r=f_r,
+        f_m=f_m,
+        theta_x=jnp.ones((1,)),
+        n_points=n_points,
+    )
+
+    xzl = {
+        "x": jnp.asarray(0.5),
+        "z": jnp.asarray([0.2]),
+        "l": jnp.asarray([0.1]),
+    }
+    theta = {
+        "theta_m": jnp.asarray(0.0),
+        "theta_r": jnp.asarray(0.0),
+        "theta_pi": jnp.asarray(0.0),
+        "theta_y": jnp.asarray(0.0),
+    }
+    assert jnp.isclose(r(xzl, theta), 1.0)


### PR DESCRIPTION
- We were calling softmax on each mixture logit value, as opposed to softmax across the logits. This pr fixes that. 
- Added a test that checks the probabilities of `pi_ul` sum to 1. I think the subtlety of this error was that in the original, if each `pi_ul(c)` is unique or were proportionally related, we would still get the correct probabilities. In this test, we use a unique `pi_ul` is used each time, such that the old approach would fail, but new one won't.