### PR TITLE
Labels for graphs created by algorithms

### DIFF
--- a/src/causalprog/algorithms/do.py
+++ b/src/causalprog/algorithms/do.py
@@ -53,7 +53,7 @@ def removable_nodes(graph: Graph, nodes: dict[str, Node]) -> tuple[str, ...]:
     return tuple(removable)
 
 
-def do(graph: Graph, node: str, value: float, label: str | None = None) -> Graph:
+def do(graph: Graph, node: str, value: float, *, label: str | None = None) -> Graph:
     """
     Apply do to a graph.
 

--- a/src/causalprog/algorithms/replace_node.py
+++ b/src/causalprog/algorithms/replace_node.py
@@ -7,7 +7,8 @@ def replace_node(
     graph: Graph,
     node_label_to_replace: str,
     replacement_node: Node,
-    new_graph_label: str | None = None,
+    *
+    label: str | None = None,
 ) -> Graph:
     """
     Replace a node in a graph.
@@ -16,7 +17,7 @@ def replace_node(
         graph: The graph to replace a node in.
         node_label_to_replace: The label of the node to be replaced.
         replacement_node: The new node to be inserted.
-        new_graph_label: The label of the new graph.
+        label: The label of the new graph.
 
     Returns:
         A copy of the graph with the replacement made.
@@ -26,7 +27,7 @@ def replace_node(
         msg = "Node being replaced cannot be parent of replacement node"
         raise ValueError(msg)
 
-    g = graph.copy(label=new_graph_label)
+    g = graph.copy(label=label)
 
     new_edges = []
     for start, end in g.edges:

--- a/src/causalprog/algorithms/replace_node.py
+++ b/src/causalprog/algorithms/replace_node.py
@@ -7,7 +7,7 @@ def replace_node(
     graph: Graph,
     node_label_to_replace: str,
     replacement_node: Node,
-    *
+    *,
     label: str | None = None,
 ) -> Graph:
     """


### PR DESCRIPTION
In graph and node creating, `label=` is always a kwarg-only argument that is passed label of the newly created object. Currently in algorithms that create copies graphs, there is a slightly inconsistent syntax for providing the label of the new graph copy.

This PR updates the algorithms to always have a kwarg-only argument `label=` that can be passed the new label (with sensible defaults of the graph-being-copied's label plus a suffix)