### PR TITLE
Add cancel-in-progress to tests workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Realised that our CI workflows don't have any concurrency groups. This means that, when a PR is updated for example, the workflows that were triggered on the old HEAD commit continue to run, in addition to a new round of workflows being triggered which makes the currently-running version redundant (in the vast majority of cases).

As such; this PR just adds concurrency groups for all of our workflows, and sets them to cancel if they are running when an update is pushed to the branch they are currently running on.

- For the tests, which are quite a meaty workflow, this will save a few compute mins on GitHub runners.
- The linting completes almost immediately, but this is probably good practice so that PR authors are not notified about linting failures that they immediately spotted and fixed, but are still caught in an outdated workflow run.
- The docs workflow takes a bit longer, and there is a case to be made that we want to always have the docs built. However given that we don't retain the docs artifact unless we're publishing on `main`, I feel like we can live without intermediate docs builds. Once we get to a regular release schedule, we might want to revisit this.