### PR TITLE
Move info from README into the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ $$ \mathcal{L}(\Theta, \lambda) := \sigma(\Theta) - \lambda \left( \vert\vert \p
 
 The package also provides some basic wrappers for these solvers, for the most common techniques / algorithms that are used to solve the optimisation problems that are encountered.
 
+## Getting Started
+
+See [our documentation for information on how to get started](http://github-pages.ucl.ac.uk/causalprog/getting-started) with `causalprog`.
+
 ## About
 
 ### Project team
@@ -75,76 +79,6 @@ The package also provides some basic wrappers for these solvers, for the most co
 
 Centre for Advanced Research Computing, University College London
 ([arc.collaborations@ucl.ac.uk](mailto:arc.collaborations@ucl.ac.uk))
-
-## Getting Started
-
-### Prerequisites
-
-<!-- Any tools or versions of languages needed to run code. For example specific Python or Node versions. Minimum hardware requirements also go here. -->
-
-`causalprog` requires Python 3.11&ndash;3.13.
-
-### Installation
-
-<!-- How to build or install the application. -->
-
-We recommend installing in a project specific virtual environment. To install the latest
-development version of `causalprog` using `pip` in the currently active environment run
-
-```sh
-pip install git+https://github.com/UCL/causalprog.git
-```
-
-Alternatively create a local clone of the repository with
-
-```sh
-git clone https://github.com/UCL/causalprog.git
-```
-
-and then install in editable mode by running
-
-```sh
-pip install -e .
-```
-
-### Running tests
-
-<!-- How to run tests on your local system. -->
-
-Tests can be run across all compatible Python versions in isolated environments
-using [`tox`](https://tox.wiki/en/latest/) by running
-
-```sh
-tox
-```
-
-To run tests manually in a Python environment with `pytest` installed run
-
-```sh
-pytest tests
-```
-
-again from the root of the repository.
-
-For more information about the testing suite, please see [the contributing page](./docs/developers/contributing.md#testing-suite).
-
-### Building documentation
-
-The MkDocs HTML documentation can be built locally by running
-
-```sh
-tox -e docs
-```
-
-from the root of the repository. The built documentation will be written to
-`site`.
-
-Alternatively to build and preview the documentation locally, in a Python
-environment with the optional `docs` dependencies installed, run
-
-```sh
-mkdocs serve
-```
 
 ## Acknowledgements
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -26,7 +26,7 @@ Once all discussion topics are resolved, and the automated tests pass, your pull
 
 We recommend a slightly different installation method to that of a user if you plan to contribute to `causalprog`.
 
-1. If you are not a member of the core development team: to ensure that you have write access to (a copy of) the `causalprog` repository, please create your [own personal fork](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo) of [the `causalprog` repository](github.com/UCL/causalprog).
+1. If you are not a member of the core development team: to ensure that you have write access to (a copy of) the `causalprog` repository, please create your [own personal fork](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo) of [the `causalprog` repository](https://github.com/UCL/causalprog).
    Core developer will have write access to the `causalprog` repository so can create branches directly inside it, but are welcome to use forks too if they so wish.
 2. Use `git clone` to obtain a local copy of your fork.
 3. Install `causalprog` in editable mode, along with it's optional dependencies, via

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -31,9 +31,9 @@ We recommend a slightly different installation method to that of a user if you p
 2. Use `git clone` to obtain a local copy of your fork.
 3. Install `causalprog` in editable mode, along with it's optional dependencies, via
 
-   ```sh
-   pip install -e .[dev,docs,test]
-   ```
+```sh
+pip install -e .[dev,docs,test]
+```
 
 Don't forget to activate the Python environment you want to install `causalprog` into before running `pip install`.
 
@@ -152,7 +152,7 @@ Each markdown file will be rendered to a HTML document when the build runs, and 
 The documentation can be built locally by running
 
 ```sh
-tox -e docs
+(causalprog-environment) $ tox -e docs
 ```
 
 from the root of the repository.
@@ -162,5 +162,5 @@ Alternatively to build and preview the documentation locally, in a Python
 environment with the optional `docs` dependencies installed, run
 
 ```sh
-mkdocs serve
+(causalprog-environment) $ mkdocs serve
 ```

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,19 +1,43 @@
 # Contributing and Style Guide
 
-## Reporting bugs & suggesting enhancements
+## Getting Started: Developers
+
+### Reporting bugs & suggesting enhancements
 
 Bugs can be reported and enhancements can be suggested using the [issue tracker](https://github.com/UCL/causalprog/issues) on Github.
-Further dicussion about the bug or enhancement can take place in the Github issue.
+Further discussion about the bug or enhancement can take place in the Github issue.
 
-## Contributing code
+### Contributing code
 
 If you want to directly submit code to causalprog, you can do this by forking the causalprog repository, then submitting a pull request.
+See the [developer installation instructions](#developer-installation) if you need help forking and installing the package in editable mode.
+
 If you want to contribute, but are unsure where to start, have a look at the [issues labelled "good first issue"](https://github.com/UCL/causalprog/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 
 On opening a pull request, various linting checks and automated tests will run.
 You can click on these in the pull request to see where (if anywhere) there are issues that need fixing in your code.
+You can find more information on the [testing suite](#testing-suite) and [documentation build](#building-the-documentation) below, should you find that these checks are failing.
+You may also want to check our [style guide for docstrings](#docstring-style).
 
-## AI-assisted development
+A member of the development team will review your pull request when you mark it as ready, providing either feedback or approval.
+Once all discussion topics are resolved, and the automated tests pass, your pull request will be merged!
+
+### Developer Installation
+
+We recommend a slightly different installation method to that of a user if you plan to contribute to `causalprog`.
+
+1. If you are not a member of the core development team: to ensure that you have write access to (a copy of) the `causalprog` repository, please create your [own personal fork](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo) of [the `causalprog` repository](github.com/UCL/causalprog).
+   Core developer will have write access to the `causalprog` repository so can create branches directly inside it, but are welcome to use forks too if they so wish.
+2. Use `git clone` to obtain a local copy of your fork.
+3. Install `causalprog` in editable mode, along with it's optional dependencies, via
+
+   ```sh
+   pip install -e .[dev,docs,test]
+   ```
+
+Don't forget to activate the Python environment you want to install `causalprog` into before running `pip install`.
+
+### AI-assisted development
 
 If any LLM or other AI tool is used, this must be declared in the text of the pull request.
 Any AI-generated code must be thoroughly checked by the person opening the pull request before the PR is opened.
@@ -78,16 +102,7 @@ The package can be installed with its developer dependencies, including `pytest`
 
 ### Running the tests
 
-To run the test suite, you will need to clone the `causalprog` repository and then install `causalprog` into your developer environment with the `[dev]` optional dependencies.
-We recommend specifying an editable installation if you intend to make contributions to the package.
-
-```sh
-(causalprog-environment) $ git clone git@github.com:UCL/causalprog.git
-(causalprog-environment) $ cd causalprog
-(causalprog-environment) $ pip install -e .[dev]
-```
-
-You can then run the tests manually inside your developer environment from the root of the repository,
+To run the test suite manually, run the following command inside your developer environment from the root of the repository:
 
 ```sh
 (causalprog-environment) $ pytest tests/
@@ -128,3 +143,5 @@ Some useful fixtures that are included in the `fixtures` directory;
 
 - `ssed` and `rng_key` (`fixtures/general.py`) - sets [the PRNG Key](https://docs.jax.dev/en/latest/_autosummary/jax.random.PRNGKey.html) that should be used across all tests, to ensure repeatability.
 - `raises_context` (`fixtures/general.py`) - can be used to return a `pytest.raises` context that checks for a specific exception, including matching the error message.
+
+## Building the Documentation

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -145,3 +145,22 @@ Some useful fixtures that are included in the `fixtures` directory;
 - `raises_context` (`fixtures/general.py`) - can be used to return a `pytest.raises` context that checks for a specific exception, including matching the error message.
 
 ## Building the Documentation
+
+`causalprog` uses [MkDocs](https://www.mkdocs.org/) to build HTML documentation from the files in the `docs` directory.
+Each markdown file will be rendered to a HTML document when the build runs, and any image files or other assets that are required for the build should be placed (in an appropriate location under the) `docs` directory accordingly.
+
+The documentation can be built locally by running
+
+```sh
+tox -e docs
+```
+
+from the root of the repository.
+The built documentation will be written to `site`.
+
+Alternatively to build and preview the documentation locally, in a Python
+environment with the optional `docs` dependencies installed, run
+
+```sh
+mkdocs serve
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,21 +31,3 @@ in the directory that you just cloned.
 ### Developer Installation
 
 If you would like to contribute to `causalprog`, please see [our contributing page](./developers/contributing.md) for developer installation instructions, and developer conventions.
-
-### Building documentation
-
-The MkDocs HTML documentation can be built locally by running
-
-```sh
-tox -e docs
-```
-
-from the root of the repository. The built documentation will be written to
-`site`.
-
-Alternatively to build and preview the documentation locally, in a Python
-environment with the optional `docs` dependencies installed, run
-
-```sh
-mkdocs serve
-```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+## Prerequisites
+
+`causalprog` requires Python 3.11 - 3.14.
+You may also want to setup a Python environment into which to install the package.
+
+## User Installation
+
+We recommend installing in a project specific virtual environment.
+To install the latest development version of `causalprog` using `pip` in the currently active environment, run
+
+```sh
+pip install git+https://github.com/UCL/causalprog.git
+```
+
+Alternatively create a local clone of the repository with
+
+```sh
+git clone https://github.com/UCL/causalprog.git
+```
+
+and then install `causalprog` by running
+
+```sh
+pip install .
+```
+
+in the directory that you just cloned.
+
+### Developer Installation
+
+If you would like to contribute to `causalprog`, please see [our contributing page](./developers/contributing.md) for developer installation instructions, and developer conventions.
+
+### Building documentation
+
+The MkDocs HTML documentation can be built locally by running
+
+```sh
+tox -e docs
+```
+
+from the root of the repository. The built documentation will be written to
+`site`.
+
+Alternatively to build and preview the documentation locally, in a Python
+environment with the optional `docs` dependencies installed, run
+
+```sh
+mkdocs serve
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ theme:
 
 nav:
   - Overview: index.md
+  - Installation: getting-started.md
   - Theory:
       - Simple working example: theory/simple-working-example.md
       - Continuous treatment models: theory/continuous-treatments.md


### PR DESCRIPTION
Was preparing to work on #208 but ended up doing some tidying in the README first before I started.

This just re-jigs a few things to move them into the documentation build properly, rather than leaving them loose in the README. Notably the info about the testing suite and docs build has been combined with what we already had in `contributing.md`, and there are now separate user-installation and developer-installation instructions.